### PR TITLE
feat: make editor preview divider resizable

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
 画像を挿入すると折りたたみ表示になります。
 </textarea>
+    <div id="divider"></div>
     <div id="preview"></div>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -1,6 +1,37 @@
 const editor = document.getElementById('editor');
 const preview = document.getElementById('preview');
+const divider = document.getElementById('divider');
+const mainContainer = document.querySelector('main');
 const imageInput = document.getElementById('imageInput');
+
+// Enable drag to resize between editor and preview
+let isDragging = false;
+
+divider.addEventListener('mousedown', (e) => {
+  isDragging = true;
+  document.body.style.cursor = 'col-resize';
+  e.preventDefault();
+});
+
+document.addEventListener('mousemove', (e) => {
+  if (!isDragging) return;
+  const rect = mainContainer.getBoundingClientRect();
+  const minWidth = 100;
+  const dividerWidth = divider.offsetWidth;
+  let newEditorWidth = e.clientX - rect.left;
+  const maxWidth = rect.width - dividerWidth - minWidth;
+  if (newEditorWidth < minWidth) newEditorWidth = minWidth;
+  if (newEditorWidth > maxWidth) newEditorWidth = maxWidth;
+  editor.style.width = `${newEditorWidth}px`;
+  preview.style.width = `${rect.width - newEditorWidth - dividerWidth}px`;
+});
+
+document.addEventListener('mouseup', () => {
+  if (isDragging) {
+    isDragging = false;
+    document.body.style.cursor = '';
+  }
+});
 
 // Flags to avoid recursive scroll events
 let isSyncingEditorScroll = false;

--- a/style.css
+++ b/style.css
@@ -34,11 +34,11 @@ main {
 }
 
 textarea {
+  flex: none;
   width: 50%;
   height: 100%;
   padding: 1rem;
   border: none;
-  border-right: 2px solid #c2dbff;
   resize: none;
   font-size: 1rem;
   outline: none;
@@ -47,7 +47,15 @@ textarea {
   font-family: monospace;
 }
 
+#divider {
+  width: 5px;
+  background-color: #c2dbff;
+  cursor: col-resize;
+  flex-shrink: 0;
+}
+
 #preview {
+  flex: none;
   width: 50%;
   height: 100%;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- add draggable divider element between markdown editor and preview
- style divider and update layout to support dynamic widths
- implement drag events to resize editor and preview panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6adc62d68832fabd2c047c7999d87