### PR TITLE
Add PDF export for preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       🖼 画像を挿入
       <input type="file" id="imageInput" accept="image/*" hidden>
     </label>
+    <button id="export-pdf">📄 PDF出力</button>
   </div>
 
   <main>

--- a/script.js
+++ b/script.js
@@ -335,7 +335,8 @@ imageInput.addEventListener('change', event => {
 
 exportPdfBtn.addEventListener('click', () => {
   const win = window.open('', '', 'width=800,height=600');
-  win.document.write(`<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Preview</title><link rel="stylesheet" href="style.css"></head><body>${preview.innerHTML}</body></html>`);
+  const cssHref = document.querySelector('link[rel="stylesheet"]').href;
+  win.document.write(`<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Preview</title><link rel="stylesheet" href="${cssHref}"></head><body>${preview.innerHTML}</body></html>`);
   win.document.close();
   win.onload = () => {
     win.focus();

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const mainContainer = document.querySelector('main');
 const imageInput = document.getElementById('imageInput');
 const toc = document.getElementById('toc');
 const toolbar = document.getElementById('toolbar');
+const exportPdfBtn = document.getElementById('export-pdf');
 
 let headings = [];
 let tocItems = [];
@@ -330,5 +331,16 @@ imageInput.addEventListener('change', event => {
     update();
   };
   reader.readAsDataURL(file);
+});
+
+exportPdfBtn.addEventListener('click', () => {
+  const win = window.open('', '', 'width=800,height=600');
+  win.document.write(`<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Preview</title><link rel="stylesheet" href="style.css"></head><body>${preview.innerHTML}</body></html>`);
+  win.document.close();
+  win.onload = () => {
+    win.focus();
+    win.print();
+    win.close();
+  };
 });
 

--- a/style.css
+++ b/style.css
@@ -27,6 +27,21 @@ body {
   background: #004488;
 }
 
+#export-pdf {
+  background: #0055aa;
+  color: white;
+  padding: 0.3rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  border: none;
+  margin-left: 0.5rem;
+}
+
+#export-pdf:hover {
+  background: #004488;
+}
+
 main {
   display: flex;
   flex: 1;

--- a/style.css
+++ b/style.css
@@ -151,3 +151,10 @@ a:hover {
   text-decoration: underline;
 }
 
+@media print {
+  pre {
+    white-space: pre-wrap;
+    overflow-x: visible;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add PDF export button to toolbar
- implement PDF export by opening preview in printable window
- style export button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c75116ab84832fbd3162d6d7033615