### PR TITLE
Add Markdown and Mermaid cheat sheet help window

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <input type="file" id="imageInput" accept="image/*" hidden>
     </label>
     <button id="export-pdf">📄 PDF出力</button>
+    <button id="help-btn">❔ ヘルプ</button>
   </div>
 
   <main>
@@ -25,6 +26,37 @@
     <div id="divider"></div>
     <div id="preview"></div>
   </main>
+
+  <div id="help-window" class="hidden">
+    <button id="help-close">✖</button>
+    <h3>Markdown チートシート</h3>
+    <pre>
+# 見出し1
+## 見出し2
+
+- リスト
+1. 番号付きリスト
+
+**太字** *斜体*
+> 引用
+`コード`
+
+```
+コードブロック
+```
+
+[リンク](URL)
+    </pre>
+    <h3>Mermaid チートシート</h3>
+    <pre>
+```mermaid
+graph TD
+  A[開始] --> B{条件}
+  B -->|はい| C[処理1]
+  B -->|いいえ| D[処理2]
+```
+    </pre>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,9 @@ const imageInput = document.getElementById('imageInput');
 const toc = document.getElementById('toc');
 const toolbar = document.getElementById('toolbar');
 const exportPdfBtn = document.getElementById('export-pdf');
+const helpBtn = document.getElementById('help-btn');
+const helpWindow = document.getElementById('help-window');
+const helpClose = document.getElementById('help-close');
 
 let headings = [];
 let tocItems = [];
@@ -343,5 +346,13 @@ exportPdfBtn.addEventListener('click', () => {
     win.print();
     win.close();
   };
+});
+
+helpBtn.addEventListener('click', () => {
+  helpWindow.classList.toggle('hidden');
+});
+
+helpClose.addEventListener('click', () => {
+  helpWindow.classList.add('hidden');
 });
 

--- a/style.css
+++ b/style.css
@@ -42,6 +42,21 @@ body {
   background: #004488;
 }
 
+#help-btn {
+  background: #0055aa;
+  color: white;
+  padding: 0.3rem 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  border: none;
+  margin-left: 0.5rem;
+}
+
+#help-btn:hover {
+  background: #004488;
+}
+
 main {
   display: flex;
   flex: 1;
@@ -140,6 +155,40 @@ code {
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   color: #003366;
+}
+
+#help-window {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 320px;
+  max-height: 70vh;
+  overflow-y: auto;
+  background: #ffffff;
+  border: 1px solid #aac8ff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  z-index: 1000;
+}
+
+#help-window.hidden {
+  display: none;
+}
+
+#help-window pre {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+#help-close {
+  float: right;
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
 a {


### PR DESCRIPTION
## Summary
- Add toolbar help button that toggles Markdown & Mermaid cheat sheet
- Style floating help window and button
- Hook up JS handlers to open and close cheat sheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c78a392c5c832faa9bca33c1eca609