### PR TITLE
Add Playwright rendering test and workflow

### DIFF
--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - uses: microsoft/playwright-github-action@v1
+      - run: npx playwright install --with-deps
       - run: npm test

--- a/.github/workflows/render-test.yml
+++ b/.github/workflows/render-test.yml
@@ -1,0 +1,17 @@
+name: Render Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - uses: microsoft/playwright-github-action@v1
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "markdown-editor",
+  "version": "1.0.0",
+  "description": "Simple Markdown editor with initial rendering test",
+  "main": "script.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/tests/render.spec.js
+++ b/tests/render.spec.js
@@ -1,0 +1,9 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+test('initial page renders markdown', async ({ page }) => {
+  const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
+  await page.goto(fileUrl);
+  await expect(page.locator('#editor')).toBeVisible();
+  await expect(page.locator('#preview')).toContainText('Markdownエディタ');
+});


### PR DESCRIPTION
## Summary
- set up Playwright test to ensure initial markdown preview renders
- add GitHub Actions workflow to run rendering test in CI

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80674e2bc832f9da278c516c359f2