### PR TITLE
Avoid preview scroll while typing

### DIFF
--- a/script.js
+++ b/script.js
@@ -290,6 +290,8 @@ document.addEventListener('mouseup', () => {
 // Flags to avoid recursive scroll events
 let isSyncingEditorScroll = false;
 let isSyncingPreviewScroll = false;
+let lastEditorInputTime = 0;
+const INPUT_SCROLL_SUPPRESS_DURATION = 120;
 
 function getHeaderOffset() {
   return toolbar ? toolbar.offsetHeight : 0;
@@ -312,10 +314,17 @@ function syncScroll(source, target) {
 }
 
 editor.addEventListener('scroll', () => {
-  if (!isSyncingEditorScroll) {
-    isSyncingPreviewScroll = true;
-    syncScroll(editor, preview);
+  if (isSyncingEditorScroll) {
+    isSyncingEditorScroll = false;
+    return;
   }
+
+  if (performance.now() - lastEditorInputTime < INPUT_SCROLL_SUPPRESS_DURATION) {
+    return;
+  }
+
+  isSyncingPreviewScroll = true;
+  syncScroll(editor, preview);
   isSyncingEditorScroll = false;
 });
 
@@ -488,6 +497,7 @@ function updateTOCHighlight() {
 const imageMap = {};
 
 editor.addEventListener('input', () => {
+  lastEditorInputTime = performance.now();
   update();
   updateTOCHighlight();
 });


### PR DESCRIPTION
## Summary
- suppress scroll synchronization from editor to preview immediately after text edits so the preview no longer jumps while typing
- record the latest editor input timestamp to differentiate between manual scrolling and caret-induced scroll events

## Testing
- npm test *(fails: Playwright could not download the required browsers in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6566a79c832fbfa86c5e84afed63