### PR TITLE
Add open button for markdown loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <header id="toolbar">
     <h1 id="app-title">Markdown Editor Blue</h1>
     <div id="toolbar-actions">
+      <button id="open-md" class="toolbar-button" type="button">📂 開く</button>
       <button id="save-md" class="toolbar-button" type="button">💾 保存</button>
       <button id="export-pdf" class="toolbar-button" type="button">📄 PDF出力</button>
       <button id="insert-image" class="toolbar-button" type="button">🖼 画像を挿入</button>
@@ -29,6 +30,12 @@
       <button id="help-btn" class="toolbar-button" type="button">❔ ヘルプ</button>
     </div>
     <input type="file" id="imageInput" accept="image/*" hidden>
+    <input
+      type="file"
+      id="markdownInput"
+      accept=".md,.markdown,.txt,text/markdown"
+      hidden
+    >
   </header>
 
   <main>

--- a/tests/actions.spec.js
+++ b/tests/actions.spec.js
@@ -65,6 +65,22 @@ test('saves markdown to file', async ({ page }) => {
   expect(download.suggestedFilename()).toBe(filename);
 });
 
+test('opens markdown file into editor', async ({ page }) => {
+  await page.goto(fileUrl);
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.click('#open-md'),
+  ]);
+  page.once('dialog', dialog => dialog.accept());
+  await fileChooser.setFiles({
+    name: 'opened.md',
+    mimeType: 'text/markdown',
+    buffer: Buffer.from('# 開いたファイル', 'utf-8'),
+  });
+  await expect(page.locator('#editor')).toHaveValue('# 開いたファイル');
+  await expect(page.locator('#preview h1')).toHaveText('開いたファイル');
+});
+
 test('renders mermaid diagram in preview', async ({ page }) => {
   await page.goto(fileUrl);
   await page.waitForFunction(() => window.mermaid);


### PR DESCRIPTION
## Summary
- add an "開く" toolbar button and hidden file input to select markdown files
- load selected markdown files into the editor and preview with scroll resets and focus handling
- cover the new open workflow with a Playwright test

## Testing
- npm test *(fails: Playwright browsers are not installed in the execution environment)*
- npx playwright install --with-deps chromium *(fails: external network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced4b5ddd4832f9f5978b5c6f46601