### PR TITLE
Add English localization support

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+window.APP_CONFIG = window.APP_CONFIG || {};
+window.APP_CONFIG.defaultLanguage = 'en';

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,281 @@
+(function () {
+  const LANGUAGE_STORAGE_KEY = 'markdown-editor-language';
+  const SUPPORTED_LANGUAGES = ['en', 'ja'];
+
+  let config = { defaultLanguage: 'en' };
+  const dictionaries = new Map();
+  let fallbackDictionary = {};
+  let currentDictionary = {};
+  let currentLanguage = 'en';
+  let initialized = false;
+
+  function normalizeLanguage(lang) {
+    if (typeof lang !== 'string') {
+      return null;
+    }
+    const trimmed = lang.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const lower = trimmed.toLowerCase();
+    const [base] = lower.split('-');
+    return base;
+  }
+
+  function isSupported(lang) {
+    return SUPPORTED_LANGUAGES.includes(lang);
+  }
+
+  function getDefaultLanguage() {
+    const configured = normalizeLanguage(config.defaultLanguage);
+    if (configured && isSupported(configured)) {
+      return configured;
+    }
+    return 'en';
+  }
+
+  function getStoredLanguage() {
+    try {
+      const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+      return normalizeLanguage(stored);
+    } catch (error) {
+      console.warn('[i18n] Unable to access localStorage.', error);
+      return null;
+    }
+  }
+
+  function getBrowserLanguage() {
+    const candidates = [];
+    if (Array.isArray(navigator.languages)) {
+      candidates.push(...navigator.languages);
+    }
+    if (navigator.language) {
+      candidates.push(navigator.language);
+    }
+    for (const candidate of candidates) {
+      const normalized = normalizeLanguage(candidate);
+      if (normalized && isSupported(normalized)) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+
+  async function loadDictionary(lang) {
+    if (dictionaries.has(lang)) {
+      return dictionaries.get(lang);
+    }
+    const response = await fetch(`i18n/${lang}.json`, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Failed to load dictionary: ${lang}`);
+    }
+    const dict = await response.json();
+    dictionaries.set(lang, dict);
+    return dict;
+  }
+
+  function getMessage(dict, key) {
+    if (!dict) {
+      return undefined;
+    }
+    return key.split('.').reduce((acc, part) => {
+      if (acc && Object.prototype.hasOwnProperty.call(acc, part)) {
+        return acc[part];
+      }
+      return undefined;
+    }, dict);
+  }
+
+  function formatMessage(template, params) {
+    if (typeof template !== 'string') {
+      return template;
+    }
+    if (!params) {
+      return template;
+    }
+    return template.replace(/\{([^}]+)\}/g, (match, token) => {
+      if (Object.prototype.hasOwnProperty.call(params, token)) {
+        const value = params[token];
+        return value == null ? '' : String(value);
+      }
+      return match;
+    });
+  }
+
+  function applyToElement(element) {
+    if (!element || !element.dataset) {
+      return;
+    }
+
+    if (element.dataset.i18n) {
+      const text = t(element.dataset.i18n);
+      if (text != null) {
+        element.textContent = text;
+      }
+    }
+
+    Object.entries(element.dataset).forEach(([dataKey, value]) => {
+      if (!dataKey.startsWith('i18n') || dataKey === 'i18n') {
+        return;
+      }
+      const suffix = dataKey.slice(4);
+      if (!suffix) {
+        return;
+      }
+      const translation = t(value);
+      if (translation == null) {
+        return;
+      }
+      switch (suffix) {
+        case 'Html':
+          element.innerHTML = translation;
+          break;
+        case 'Text':
+          element.textContent = translation;
+          break;
+        case 'Value':
+          if ('value' in element) {
+            element.value = translation;
+          } else {
+            element.setAttribute('value', translation);
+          }
+          break;
+        default: {
+          const attrName = suffix
+            .replace(/^[A-Z]/, char => char.toLowerCase())
+            .replace(/[A-Z]/g, char => `-${char.toLowerCase()}`);
+          element.setAttribute(attrName, translation);
+        }
+      }
+    });
+  }
+
+  function collectElements(root) {
+    if (root instanceof Document) {
+      return [root.documentElement, ...root.querySelectorAll('*')];
+    }
+    if (root instanceof Element || root instanceof DocumentFragment) {
+      return [root, ...root.querySelectorAll('*')];
+    }
+    return [];
+  }
+
+  function applyToDOM(root) {
+    const scope = root || document;
+    const elements = collectElements(scope);
+    elements.forEach(element => {
+      if (!element || !element.dataset) {
+        return;
+      }
+      const hasI18nKeys = Object.keys(element.dataset).some(key =>
+        key === 'i18n' || key.startsWith('i18n')
+      );
+      if (hasI18nKeys) {
+        applyToElement(element);
+      }
+    });
+  }
+
+  function resolveInitialLanguage() {
+    const params = new URLSearchParams(window.location.search);
+    const queryLang = normalizeLanguage(params.get('lang'));
+    if (queryLang && isSupported(queryLang)) {
+      return queryLang;
+    }
+
+    const storedLang = getStoredLanguage();
+    if (storedLang && isSupported(storedLang)) {
+      return storedLang;
+    }
+
+    const browserLang = getBrowserLanguage();
+    if (browserLang) {
+      return browserLang;
+    }
+
+    return getDefaultLanguage();
+  }
+
+  async function setLang(lang) {
+    const normalized = normalizeLanguage(lang) || getDefaultLanguage();
+    const target = isSupported(normalized) ? normalized : getDefaultLanguage();
+    if (target === currentLanguage && initialized) {
+      return currentLanguage;
+    }
+
+    let dictionary = fallbackDictionary;
+    let fallbackUsed = false;
+    if (target !== 'en') {
+      try {
+        dictionary = await loadDictionary(target);
+      } catch (error) {
+        console.warn(`[i18n] Failed to load dictionary for ${target}.`, error);
+        dictionary = fallbackDictionary;
+        fallbackUsed = true;
+      }
+    }
+
+    currentLanguage = fallbackUsed ? 'en' : target;
+    currentDictionary = dictionary;
+    document.documentElement.setAttribute('lang', currentLanguage);
+
+    try {
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, currentLanguage);
+    } catch (error) {
+      console.warn('[i18n] Unable to persist language selection.', error);
+    }
+
+    applyToDOM();
+    document.dispatchEvent(
+      new CustomEvent('i18n:change', { detail: { lang: currentLanguage } })
+    );
+    return currentLanguage;
+  }
+
+  function t(key, params) {
+    if (typeof key !== 'string' || !key) {
+      return key;
+    }
+    const message = getMessage(currentDictionary, key);
+    if (message != null) {
+      return formatMessage(message, params);
+    }
+    const fallback = getMessage(fallbackDictionary, key);
+    if (fallback != null) {
+      return formatMessage(fallback, params);
+    }
+    return key;
+  }
+
+  async function init() {
+    if (initialized) {
+      return currentLanguage;
+    }
+
+    config = Object.assign({ defaultLanguage: 'en' }, window.APP_CONFIG || {});
+
+    fallbackDictionary = await loadDictionary('en');
+    currentDictionary = fallbackDictionary;
+    currentLanguage = 'en';
+    document.documentElement.setAttribute('lang', currentLanguage);
+
+    const initialLanguage = resolveInitialLanguage();
+    await setLang(initialLanguage);
+
+    initialized = true;
+    return currentLanguage;
+  }
+
+  window.i18n = {
+    init,
+    setLang,
+    t,
+    applyToDOM,
+    getCurrentLang() {
+      return currentLanguage;
+    },
+    getSupportedLanguages() {
+      return [...SUPPORTED_LANGUAGES];
+    }
+  };
+})();

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,50 @@
+{
+  "app": {
+    "title": "Markdown Editor Blue"
+  },
+  "toolbar": {
+    "open": "📂 Open",
+    "save": "💾 Save",
+    "exportPdf": "📄 Export PDF",
+    "insertImage": "🖼 Insert Image",
+    "template": "📋 Templates",
+    "help": "❔ Help",
+    "languageLabel": "Language"
+  },
+  "language": {
+    "english": "English",
+    "japanese": "日本語"
+  },
+  "templates": {
+    "meetingNotes": "Meeting Notes",
+    "systemChangeOverview": "System Change Overview",
+    "systemChangeChecklist": "System Change Checklist",
+    "readme": "Readme",
+    "releaseNotes": "Release Notes"
+  },
+  "dialogs": {
+    "replaceFile": "Replace the current content with the selected file?",
+    "fileReadErrorLog": "Failed to load the Markdown file",
+    "fileReadErrorAlert": "Failed to load the Markdown file. Please check the file and try again.",
+    "replaceTemplate": "Replace the current content with the selected template?",
+    "templateLoadErrorLog": "Failed to load the template",
+    "templateLoadErrorAlert": "Failed to load the template. Please make sure the template files are available.",
+    "saveFilenamePrompt": "Enter a file name to save",
+    "defaultFileName": "document.md",
+    "previewTitle": "Preview"
+  },
+  "editor": {
+    "placeholder": "Type Markdown here..."
+  },
+  "help": {
+    "close": "Close",
+    "markdownTitle": "Markdown Cheat Sheet",
+    "markdownCheatsheet": "# Heading 1\n## Heading 2\n\n- List\n1. Numbered list\n\n**Bold** *Italic*\n> Quote\n`Code`\n\n```\nCode block\n```\n\n[Link](URL)",
+    "mermaidTitle": "Mermaid Cheat Sheet",
+    "mermaidCheatsheet": "```mermaid\ngraph TD\n  A[Start] --> B{Condition}\n  B -->|Yes| C[Process 1]\n  B -->|No| D[Process 2]\n```"
+  },
+  "image": {
+    "fallback": "[Image: {filename}]",
+    "markdownTemplate": "\n<!-- image:{filename} -->\n[Image: {filename}]\n<!-- /image -->\n"
+  }
+}

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -1,0 +1,50 @@
+{
+  "app": {
+    "title": "Markdown Editor Blue"
+  },
+  "toolbar": {
+    "open": "📂 開く",
+    "save": "💾 保存",
+    "exportPdf": "📄 PDF出力",
+    "insertImage": "🖼 画像を挿入",
+    "template": "📋 テンプレート",
+    "help": "❔ ヘルプ",
+    "languageLabel": "言語"
+  },
+  "language": {
+    "english": "English",
+    "japanese": "日本語"
+  },
+  "templates": {
+    "meetingNotes": "議事録",
+    "systemChangeOverview": "システム変更概要",
+    "systemChangeChecklist": "システム変更チェックリスト",
+    "readme": "Readme",
+    "releaseNotes": "リリースノート"
+  },
+  "dialogs": {
+    "replaceFile": "現在の内容を開くファイルの内容で置き換えます。よろしいですか？",
+    "fileReadErrorLog": "Markdownファイルの読み込みに失敗しました",
+    "fileReadErrorAlert": "Markdownファイルの読み込みに失敗しました。ファイルを確認してください。",
+    "replaceTemplate": "現在の内容をテンプレートで置き換えます。よろしいですか？",
+    "templateLoadErrorLog": "テンプレートの読み込みに失敗しました",
+    "templateLoadErrorAlert": "テンプレートの読み込みに失敗しました。テンプレートファイルの配置を確認してください。",
+    "saveFilenamePrompt": "保存するファイル名を入力してください",
+    "defaultFileName": "document.md",
+    "previewTitle": "プレビュー"
+  },
+  "editor": {
+    "placeholder": "ここにMarkdownを入力..."
+  },
+  "help": {
+    "close": "閉じる",
+    "markdownTitle": "Markdown チートシート",
+    "markdownCheatsheet": "# 見出し1\n## 見出し2\n\n- リスト\n1. 番号付きリスト\n\n**太字** *斜体*\n> 引用\n`コード`\n\n```\nコードブロック\n```\n\n[リンク](URL)",
+    "mermaidTitle": "Mermaid チートシート",
+    "mermaidCheatsheet": "```mermaid\ngraph TD\n  A[開始] --> B{条件}\n  B -->|はい| C[処理1]\n  B -->|いいえ| D[処理2]\n```"
+  },
+  "image": {
+    "fallback": "[画像: {filename}]",
+    "markdownTemplate": "\n<!-- image:{filename} -->\n[画像: {filename}]\n<!-- /image -->\n"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Markdown Editor Blue</title>
@@ -8,12 +8,19 @@
 </head>
 <body>
   <header id="toolbar">
-    <h1 id="app-title">Markdown Editor Blue</h1>
+    <h1 id="app-title" data-i18n="app.title">Markdown Editor Blue</h1>
     <div id="toolbar-actions">
-      <button id="open-md" class="toolbar-button" type="button">📂 開く</button>
-      <button id="save-md" class="toolbar-button" type="button">💾 保存</button>
-      <button id="export-pdf" class="toolbar-button" type="button">📄 PDF出力</button>
-      <button id="insert-image" class="toolbar-button" type="button">🖼 画像を挿入</button>
+      <button id="open-md" class="toolbar-button" type="button" data-i18n="toolbar.open">📂 Open</button>
+      <button id="save-md" class="toolbar-button" type="button" data-i18n="toolbar.save">💾 Save</button>
+      <button id="export-pdf" class="toolbar-button" type="button" data-i18n="toolbar.exportPdf">📄 Export PDF</button>
+      <button
+        id="insert-image"
+        class="toolbar-button"
+        type="button"
+        data-i18n="toolbar.insertImage"
+      >
+        🖼 Insert Image
+      </button>
       <div id="template-menu">
         <button
           id="template-btn"
@@ -22,12 +29,20 @@
           aria-haspopup="true"
           aria-expanded="false"
           aria-controls="template-options"
+          data-i18n="toolbar.template"
         >
-          📋 テンプレート
+          📋 Templates
         </button>
         <div id="template-options" role="menu" aria-labelledby="template-btn" hidden></div>
       </div>
-      <button id="help-btn" class="toolbar-button" type="button">❔ ヘルプ</button>
+      <button id="help-btn" class="toolbar-button" type="button" data-i18n="toolbar.help">
+        ❔ Help
+      </button>
+      <label for="lang-switch" id="lang-label" data-i18n="toolbar.languageLabel">Language</label>
+      <select id="lang-switch">
+        <option value="en" data-i18n="language.english">English</option>
+        <option value="ja" data-i18n="language.japanese">日本語</option>
+      </select>
     </div>
     <input type="file" id="imageInput" accept="image/*" hidden>
     <input
@@ -41,7 +56,11 @@
   <main>
     <div id="toc"></div>
     <div id="toc-divider"></div>
-    <textarea id="editor" placeholder="ここにMarkdownを入力..."># Markdownエディタ
+    <textarea
+      id="editor"
+      placeholder="Type Markdown here..."
+      data-i18n-placeholder="editor.placeholder"
+    ># Markdownエディタ
 
 画像を挿入すると折りたたみ表示になります。
 </textarea>
@@ -50,38 +69,40 @@
   </main>
 
   <div id="help-window" class="hidden">
-    <button id="help-close">✖</button>
-    <h3>Markdown チートシート</h3>
-    <pre>
-# 見出し1
-## 見出し2
+    <button id="help-close" data-i18n-aria-label="help.close">✖</button>
+    <h3 data-i18n="help.markdownTitle">Markdown Cheat Sheet</h3>
+    <pre data-i18n="help.markdownCheatsheet">
+# Heading 1
+## Heading 2
 
-- リスト
-1. 番号付きリスト
+- List
+1. Numbered list
 
-**太字** *斜体*
-> 引用
-`コード`
+**Bold** *Italic*
+> Quote
+`Code`
 
 ```
-コードブロック
+Code block
 ```
 
-[リンク](URL)
+[Link](URL)
     </pre>
-    <h3>Mermaid チートシート</h3>
-    <pre>
+    <h3 data-i18n="help.mermaidTitle">Mermaid Cheat Sheet</h3>
+    <pre data-i18n="help.mermaidCheatsheet">
 ```mermaid
 graph TD
-  A[開始] --> B{条件}
-  B -->|はい| C[処理1]
-  B -->|いいえ| D[処理2]
+  A[Start] --> B{Condition}
+  B -->|Yes| C[Process 1]
+  B -->|No| D[Process 2]
 ```
     </pre>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+  <script src="config.js"></script>
+  <script src="i18n.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,986 +1,1052 @@
-const editor = document.getElementById('editor');
-const preview = document.getElementById('preview');
-const divider = document.getElementById('divider');
-const tocDivider = document.getElementById('toc-divider');
-const mainContainer = document.querySelector('main');
-const imageInput = document.getElementById('imageInput');
-const insertImageBtn = document.getElementById('insert-image');
-const toc = document.getElementById('toc');
-const toolbar = document.getElementById('toolbar');
-const exportPdfBtn = document.getElementById('export-pdf');
-const saveMdBtn = document.getElementById('save-md');
-const openMdBtn = document.getElementById('open-md');
-const helpBtn = document.getElementById('help-btn');
-const helpWindow = document.getElementById('help-window');
-const helpClose = document.getElementById('help-close');
-const templateBtn = document.getElementById('template-btn');
-const templateOptions = document.getElementById('template-options');
-const markdownInput = document.getElementById('markdownInput');
-
-const templates = [
-  { label: '議事録', path: 'template/meeting-notes.md' },
-  { label: 'システム変更概要', path: 'template/system-change-overview.md' },
-  { label: 'システム変更チェックリスト', path: 'template/system-change-checklist.md' },
-  { label: 'Readme', path: 'template/readme.md' },
-  { label: 'リリースノート', path: 'template/release-notes.md' }
-];
-
-if (insertImageBtn && imageInput) {
-  insertImageBtn.addEventListener('click', () => {
-    imageInput.click();
-  });
+async function bootstrap() {
+  await i18n.init();
+  startApp();
 }
 
-if (openMdBtn && markdownInput) {
-  openMdBtn.addEventListener('click', () => {
-    markdownInput.click();
-  });
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+} else {
+  bootstrap();
+}
 
-  markdownInput.addEventListener('change', event => {
-    const [file] = event.target.files || [];
-    if (!file) {
-      return;
-    }
+function startApp() {
+  const editor = document.getElementById('editor');
+  const preview = document.getElementById('preview');
+  const divider = document.getElementById('divider');
+  const tocDivider = document.getElementById('toc-divider');
+  const mainContainer = document.querySelector('main');
+  const imageInput = document.getElementById('imageInput');
+  const insertImageBtn = document.getElementById('insert-image');
+  const toc = document.getElementById('toc');
+  const toolbar = document.getElementById('toolbar');
+  const exportPdfBtn = document.getElementById('export-pdf');
+  const saveMdBtn = document.getElementById('save-md');
+  const openMdBtn = document.getElementById('open-md');
+  const helpBtn = document.getElementById('help-btn');
+  const helpWindow = document.getElementById('help-window');
+  const helpClose = document.getElementById('help-close');
+  const templateBtn = document.getElementById('template-btn');
+  const templateOptions = document.getElementById('template-options');
+  const markdownInput = document.getElementById('markdownInput');
+  const langSwitch = document.getElementById('lang-switch');
 
-    const shouldReplace =
-      !editor.value.trim() ||
-      confirm('現在の内容を開くファイルの内容で置き換えます。よろしいですか？');
+  const templates = [
+    { key: 'templates.meetingNotes', path: 'template/meeting-notes.md' },
+    { key: 'templates.systemChangeOverview', path: 'template/system-change-overview.md' },
+    { key: 'templates.systemChangeChecklist', path: 'template/system-change-checklist.md' },
+    { key: 'templates.readme', path: 'template/readme.md' },
+    { key: 'templates.releaseNotes', path: 'template/release-notes.md' }
+  ];
 
-    if (!shouldReplace) {
-      markdownInput.value = '';
-      return;
-    }
+  const updateDocumentTitle = () => {
+    document.title = i18n.t('app.title');
+  };
 
-    const reader = new FileReader();
+  updateDocumentTitle();
 
-    reader.onload = loadEvent => {
-      const { result } = loadEvent.target || {};
-      if (typeof result !== 'string') {
+  if (langSwitch) {
+    langSwitch.value = i18n.getCurrentLang();
+    langSwitch.addEventListener('change', event => {
+      i18n.setLang(event.target.value);
+    });
+  }
+
+  if (insertImageBtn && imageInput) {
+    insertImageBtn.addEventListener('click', () => {
+      imageInput.click();
+    });
+  }
+
+  if (openMdBtn && markdownInput) {
+    openMdBtn.addEventListener('click', () => {
+      markdownInput.click();
+    });
+
+    markdownInput.addEventListener('change', event => {
+      const [file] = event.target.files || [];
+      if (!file) {
+        return;
+      }
+
+      const shouldReplace =
+        !editor.value.trim() ||
+        confirm(i18n.t('dialogs.replaceFile'));
+
+      if (!shouldReplace) {
         markdownInput.value = '';
         return;
       }
 
-      editor.value = result;
-      editor.selectionStart = editor.selectionEnd = 0;
+      const reader = new FileReader();
 
-      if (typeof editor.focus === 'function') {
-        try {
-          editor.focus({ preventScroll: true });
-        } catch (err) {
-          editor.focus();
+      reader.onload = loadEvent => {
+        const { result } = loadEvent.target || {};
+        if (typeof result !== 'string') {
+          markdownInput.value = '';
+          return;
         }
-      }
 
-      update();
-      adjustTOCPosition();
-      updateTOCHighlight();
+        editor.value = result;
+        editor.selectionStart = editor.selectionEnd = 0;
 
-      const resetScrollPositions = () => {
-        editor.scrollTop = 0;
-        preview.scrollTop = 0;
-        if (toc) {
-          toc.scrollTop = 0;
+        if (typeof editor.focus === 'function') {
+          try {
+            editor.focus({ preventScroll: true });
+          } catch (err) {
+            editor.focus();
+          }
         }
+
+        update();
+        adjustTOCPosition();
+        updateTOCHighlight();
+
+        const resetScrollPositions = () => {
+          editor.scrollTop = 0;
+          preview.scrollTop = 0;
+          if (toc) {
+            toc.scrollTop = 0;
+          }
+        };
+
+        resetScrollPositions();
+        requestAnimationFrame(resetScrollPositions);
+        isPreviewManuallyPositioned = false;
+
+        markdownInput.value = '';
       };
 
-      resetScrollPositions();
-      requestAnimationFrame(resetScrollPositions);
-      isPreviewManuallyPositioned = false;
+      reader.onerror = () => {
+        console.error(i18n.t('dialogs.fileReadErrorLog'));
+        alert(i18n.t('dialogs.fileReadErrorAlert'));
+        markdownInput.value = '';
+      };
 
-      markdownInput.value = '';
-    };
+      reader.readAsText(file, 'utf-8');
+    });
+  }
 
-    reader.onerror = () => {
-      console.error('Markdownファイルの読み込みに失敗しました');
-      alert('Markdownファイルの読み込みに失敗しました。ファイルを確認してください。');
-      markdownInput.value = '';
-    };
+  let templateButtons = [];
+  let currentTemplateIndex = -1;
+  let closeTemplateMenu = () => {};
 
-    reader.readAsText(file, 'utf-8');
-  });
-}
+  function buildTemplateOptions() {
+    if (!templateOptions) {
+      templateButtons = [];
+      return;
+    }
 
-if (templateBtn && templateOptions) {
-  const templateButtons = [];
+    templateOptions.innerHTML = '';
+    templateButtons = [];
 
-  templates.forEach(({ label, path }) => {
+  templates.forEach(({ key, path }) => {
     const optionBtn = document.createElement('button');
     optionBtn.type = 'button';
     optionBtn.className = 'template-option';
-    optionBtn.textContent = label;
     optionBtn.dataset.path = path;
+    optionBtn.dataset.i18n = key;
     optionBtn.setAttribute('role', 'menuitem');
     templateOptions.appendChild(optionBtn);
     templateButtons.push(optionBtn);
+    i18n.applyToDOM(optionBtn);
   });
 
-  let currentTemplateIndex = -1;
+  i18n.applyToDOM(templateOptions);
+}
 
-  const focusOption = index => {
-    if (!templateButtons.length) return;
-    const normalizedIndex =
-      (index + templateButtons.length) % templateButtons.length;
-    const option = templateButtons[normalizedIndex];
-    if (option) {
-      option.focus();
-      currentTemplateIndex = normalizedIndex;
-    }
-  };
+  if (templateBtn && templateOptions) {
+    buildTemplateOptions();
 
-  const openTemplateMenu = (startIndex = 0) => {
-    if (!templateButtons.length) return;
-    templateOptions.hidden = false;
-    templateBtn.setAttribute('aria-expanded', 'true');
-    focusOption(startIndex);
-  };
-
-  const closeTemplateMenu = () => {
-    if (templateOptions.hidden) return;
-    templateOptions.hidden = true;
-    templateBtn.setAttribute('aria-expanded', 'false');
-    currentTemplateIndex = -1;
-  };
-
-  const applyTemplate = async templatePath => {
-    if (!templatePath) return;
-
-    if (editor.value.trim() && !confirm('現在の内容をテンプレートで置き換えます。よろしいですか？')) {
-      return;
-    }
-
-    try {
-      const response = await fetch(templatePath);
-      if (!response.ok) {
-        throw new Error(`Failed to load template: ${response.status}`);
+    const focusOption = index => {
+      if (!templateButtons.length) return;
+      const normalizedIndex =
+        (index + templateButtons.length) % templateButtons.length;
+      const option = templateButtons[normalizedIndex];
+      if (option) {
+        option.focus();
+        currentTemplateIndex = normalizedIndex;
       }
-      const text = await response.text();
-      editor.value = text;
-      editor.selectionStart = editor.selectionEnd = 0;
+    };
 
-      if (typeof editor.focus === 'function') {
-        try {
-          editor.focus({ preventScroll: true });
-        } catch (err) {
-          editor.focus();
+    const openTemplateMenu = (startIndex = 0) => {
+      if (!templateButtons.length) return;
+      templateOptions.hidden = false;
+      templateBtn.setAttribute('aria-expanded', 'true');
+      focusOption(startIndex);
+    };
+
+    const closeMenu = () => {
+      if (templateOptions.hidden) return;
+      templateOptions.hidden = true;
+      templateBtn.setAttribute('aria-expanded', 'false');
+      currentTemplateIndex = -1;
+    };
+
+    const applyTemplate = async templatePath => {
+      if (!templatePath) return;
+
+      if (editor.value.trim() && !confirm(i18n.t('dialogs.replaceTemplate'))) {
+        return;
+      }
+
+      try {
+        const response = await fetch(templatePath);
+        if (!response.ok) {
+          throw new Error(`Failed to load template: ${response.status}`);
         }
-      }
+        const text = await response.text();
+        editor.value = text;
+        editor.selectionStart = editor.selectionEnd = 0;
 
-      update();
-      adjustTOCPosition();
-      updateTOCHighlight();
-
-      const resetScrollPositions = () => {
-        editor.scrollTop = 0;
-        preview.scrollTop = 0;
-        if (toc) {
-          toc.scrollTop = 0;
+        if (typeof editor.focus === 'function') {
+          try {
+            editor.focus({ preventScroll: true });
+          } catch (err) {
+            editor.focus();
+          }
         }
-      };
 
-      resetScrollPositions();
-      requestAnimationFrame(resetScrollPositions);
-      isPreviewManuallyPositioned = false;
-    } catch (error) {
-      console.error('テンプレートの読み込みに失敗しました', error);
-      alert('テンプレートの読み込みに失敗しました。テンプレートファイルの配置を確認してください。');
-    }
-  };
-
-  templateBtn.addEventListener('click', () => {
-    if (templateOptions.hidden) {
-      openTemplateMenu();
-    } else {
-      closeTemplateMenu();
-    }
-  });
-
-  templateBtn.addEventListener('keydown', event => {
-    if (
-      event.key === 'ArrowDown' ||
-      event.key === 'ArrowUp' ||
-      event.key === 'Enter' ||
-      event.key === ' ' ||
-      event.key === 'Spacebar'
-    ) {
-      event.preventDefault();
-      if (templateOptions.hidden) {
-        const startIndex =
-          event.key === 'ArrowUp' && templateButtons.length
-            ? templateButtons.length - 1
-            : 0;
-        openTemplateMenu(startIndex);
-      }
-    } else if (event.key === 'Escape' && !templateOptions.hidden) {
-      event.preventDefault();
-      closeTemplateMenu();
-    }
-  });
-
-  templateOptions.addEventListener('focusin', event => {
-    const option = event.target.closest('.template-option');
-    if (!option) return;
-    currentTemplateIndex = templateButtons.indexOf(option);
-  });
-
-  templateOptions.addEventListener('keydown', event => {
-    if (!templateButtons.length) return;
-
-    switch (event.key) {
-      case 'ArrowDown':
-        event.preventDefault();
-        focusOption(currentTemplateIndex + 1);
-        break;
-      case 'ArrowUp':
-        event.preventDefault();
-        focusOption(currentTemplateIndex - 1);
-        break;
-      case 'Home':
-        event.preventDefault();
-        focusOption(0);
-        break;
-      case 'End':
-        event.preventDefault();
-        focusOption(templateButtons.length - 1);
-        break;
-      case 'Escape':
-        event.preventDefault();
-        closeTemplateMenu();
-        templateBtn.focus();
-        break;
-      case 'Tab':
-        closeTemplateMenu();
-        break;
-      default:
-        break;
-    }
-  });
-
-  templateOptions.addEventListener('click', event => {
-    const option = event.target.closest('.template-option');
-    if (!option) return;
-    event.stopPropagation();
-    closeTemplateMenu();
-    applyTemplate(option.dataset.path);
-  });
-
-  document.addEventListener('click', event => {
-    if (
-      templateOptions.hidden ||
-      templateOptions.contains(event.target) ||
-      templateBtn.contains(event.target)
-    ) {
-      return;
-    }
-    closeTemplateMenu();
-  });
-
-  document.addEventListener('keydown', event => {
-    if (event.key === 'Escape' && !templateOptions.hidden) {
-      closeTemplateMenu();
-      templateBtn.focus();
-    }
-  });
-}
-
-let headings = [];
-let tocItems = [];
-let headingPositions = [];
-let previewTaskCheckboxMappings = [];
-
-if (window.mermaid) {
-  mermaid.initialize({
-    startOnLoad: false,
-    securityLevel: 'loose',
-    flowchart: { htmlLabels: true }
-  });
-}
-
-function escapeHtml(str) {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-// Convert mermaid code fences to diagram containers
-marked.use({
-  renderer: {
-    code(code, infostring, escaped) {
-      const lang = (infostring || '').trim().toLowerCase();
-      if (lang === 'mermaid') {
-        return `<div class="mermaid">${escapeHtml(code)}</div>`;
-      }
-      return false; // use default renderer
-    }
-  }
-});
-
-// Enable drag to resize panes
-let isDraggingEditor = false;
-let isDraggingTOC = false;
-
-divider.addEventListener('mousedown', e => {
-  isDraggingEditor = true;
-  document.body.style.cursor = 'col-resize';
-  e.preventDefault();
-});
-
-tocDivider.addEventListener('mousedown', e => {
-  isDraggingTOC = true;
-  document.body.style.cursor = 'col-resize';
-  e.preventDefault();
-});
-
-document.addEventListener('mousemove', e => {
-  const rect = mainContainer.getBoundingClientRect();
-  const minWidth = 100;
-  if (isDraggingEditor) {
-    const tocWidth = toc.offsetWidth + tocDivider.offsetWidth;
-    const dividerWidth = divider.offsetWidth;
-    let newEditorWidth = e.clientX - rect.left - tocWidth;
-    const maxWidth = rect.width - tocWidth - dividerWidth - minWidth;
-    if (newEditorWidth < minWidth) newEditorWidth = minWidth;
-    if (newEditorWidth > maxWidth) newEditorWidth = maxWidth;
-    editor.style.width = `${newEditorWidth}px`;
-  } else if (isDraggingTOC) {
-    const dividerWidth = tocDivider.offsetWidth;
-    let newTocWidth = e.clientX - rect.left;
-    const maxWidth = rect.width - dividerWidth - divider.offsetWidth - editor.offsetWidth - minWidth;
-    if (newTocWidth < minWidth) newTocWidth = minWidth;
-    if (newTocWidth > maxWidth) newTocWidth = maxWidth;
-    toc.style.width = `${newTocWidth}px`;
-  }
-});
-
-document.addEventListener('mouseup', () => {
-  if (isDraggingEditor || isDraggingTOC) {
-    isDraggingEditor = false;
-    isDraggingTOC = false;
-    document.body.style.cursor = '';
-  }
-});
-
-// Flags to avoid recursive scroll events
-let isSyncingEditorScroll = false;
-let isSyncingPreviewScroll = false;
-let editorScrollSuppressUntil = 0;
-let previewScrollSuppressUntil = 0;
-const INPUT_SCROLL_SUPPRESS_DURATION = 400;
-const PREVIEW_RENDER_SCROLL_SUPPRESS_DURATION = 400;
-const MANUAL_SCROLL_INTENT_DURATION = 1200;
-let editorManualScrollIntentUntil = 0;
-let isEditorScrollbarDragActive = false;
-let isPreviewManuallyPositioned = false;
-
-function extendEditorScrollSuppression(duration = INPUT_SCROLL_SUPPRESS_DURATION) {
-  const targetTime = performance.now() + duration;
-  if (targetTime > editorScrollSuppressUntil) {
-    editorScrollSuppressUntil = targetTime;
-  }
-  if (!isEditorScrollbarDragActive) {
-    editorManualScrollIntentUntil = 0;
-  }
-}
-
-function getHeaderOffset() {
-  return toolbar ? toolbar.offsetHeight : 0;
-}
-
-function registerEditorScrollIntent(duration = MANUAL_SCROLL_INTENT_DURATION) {
-  if (duration === Infinity) {
-    editorManualScrollIntentUntil = Infinity;
-    return;
-  }
-
-  if (editorManualScrollIntentUntil === Infinity) {
-    return;
-  }
-
-  const targetTime = performance.now() + duration;
-  if (targetTime > editorManualScrollIntentUntil) {
-    editorManualScrollIntentUntil = targetTime;
-  }
-}
-
-function adjustTOCPosition() {
-  const offset = getHeaderOffset();
-  document.documentElement.style.setProperty('--header-offset', offset + 'px');
-}
-
-window.addEventListener('load', adjustTOCPosition);
-window.addEventListener('resize', adjustTOCPosition);
-
-function syncScroll(source, target) {
-  const sourceMax = source.scrollHeight - source.clientHeight;
-  const targetMax = target.scrollHeight - target.clientHeight;
-  if (sourceMax <= 0 || targetMax <= 0) return;
-  const ratio = source.scrollTop / sourceMax;
-  target.scrollTop = ratio * targetMax;
-}
-
-editor.addEventListener('scroll', () => {
-  const now = performance.now();
-  if (isSyncingEditorScroll) {
-    isSyncingEditorScroll = false;
-    return;
-  }
-
-  const hasManualIntent =
-    editorManualScrollIntentUntil === Infinity ||
-    now < editorManualScrollIntentUntil;
-
-  if (!hasManualIntent) {
-    return;
-  }
-
-  if (now < editorScrollSuppressUntil || now < previewScrollSuppressUntil) {
-    return;
-  }
-
-  if (isPreviewManuallyPositioned) {
-    return;
-  }
-
-  isSyncingPreviewScroll = true;
-  syncScroll(editor, preview);
-  isSyncingEditorScroll = false;
-});
-
-preview.addEventListener('scroll', () => {
-  if (isSyncingPreviewScroll) {
-    isSyncingPreviewScroll = false;
-    return;
-  }
-
-  if (performance.now() < previewScrollSuppressUntil) {
-    return;
-  }
-
-  isSyncingEditorScroll = true;
-  syncScroll(preview, editor);
-});
-
-// プレビューを更新（Base64を抽出して表示）
-function clampPreviewScrollTop(value) {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  const maxScrollTop = Math.max(0, preview.scrollHeight - preview.clientHeight);
-  if (maxScrollTop <= 0) {
-    return 0;
-  }
-  if (value <= 0) {
-    return 0;
-  }
-  return Math.min(value, maxScrollTop);
-}
-
-function restorePreviewScrollPosition(targetScrollTop) {
-  const clamped = clampPreviewScrollTop(targetScrollTop);
-  const prevSuppressUntil = previewScrollSuppressUntil;
-  previewScrollSuppressUntil = Math.max(prevSuppressUntil, performance.now() + 50);
-  isSyncingPreviewScroll = true;
-  preview.scrollTop = clamped;
-  isSyncingPreviewScroll = false;
-}
-
-function update() {
-  const renderStart = performance.now();
-  const raw = editor.value;
-  const previousScrollTop = preview.scrollTop;
-
-  // Markdownにある <!-- image:filename --> ～ <!-- /image --> を展開
-  const expanded = raw.replace(/<!-- image:(.*?) -->\s*\n\[画像: .*?\]\s*\n<!-- \/image -->/g, (match, filename) => {
-    const matchBase64 = imageMap[filename.trim()];
-    if (matchBase64) {
-      return `![${filename}](${matchBase64})`;
-    } else {
-      return `[画像: ${filename}]`; // 念のため fallback
-    }
-  });
-
-  preview.innerHTML = marked.parse(expanded, { breaks: true, mangle: false });
-  updatePreviewTaskCheckboxes(raw);
-
-  // Fallback: convert any remaining mermaid code blocks after parsing
-  preview.querySelectorAll('pre code.language-mermaid').forEach(block => {
-    const pre = block.parentElement;
-    const div = document.createElement('div');
-    div.className = 'mermaid';
-    div.textContent = block.textContent;
-    pre.replaceWith(div);
-  });
-
-  if (window.mermaid) {
-    try {
-      const nodes = preview.querySelectorAll('.mermaid');
-      if (mermaid.run) {
-        mermaid.run({ nodes });
-      } else if (mermaid.init) {
-        mermaid.init(undefined, nodes);
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  }
-  buildTOC();
-
-  const renderEnd = performance.now();
-  const renderDuration = renderEnd - renderStart;
-  previewScrollSuppressUntil =
-    renderEnd +
-    Math.max(PREVIEW_RENDER_SCROLL_SUPPRESS_DURATION, renderDuration);
-
-  const restore = () => restorePreviewScrollPosition(previousScrollTop);
-  restore();
-  requestAnimationFrame(restore);
-  requestAnimationFrame(() => requestAnimationFrame(restore));
-
-  return renderDuration;
-}
-
-function updatePreviewTaskCheckboxes(raw) {
-  previewTaskCheckboxMappings = [];
-  const lines = raw.split('\n');
-  let index = 0;
-  let inCode = false;
-  const taskPattern = /^(\s*)(?:[*+-]|\d+[.)])\s+\[( |x|X)\]/;
-
-  for (const line of lines) {
-    const fence = line.match(/^```/);
-    if (fence) {
-      inCode = !inCode;
-      index += line.length + 1;
-      continue;
-    }
-
-    if (!inCode && taskPattern.test(line)) {
-      const bracketIndex = line.indexOf('[');
-      if (bracketIndex !== -1) {
-        previewTaskCheckboxMappings.push({ index: index + bracketIndex + 1 });
-      }
-    }
-
-    index += line.length + 1;
-  }
-
-  const checkboxes = preview.querySelectorAll('input[type="checkbox"]');
-  checkboxes.forEach((checkbox, idx) => {
-    const mapping = previewTaskCheckboxMappings[idx];
-    if (!mapping) {
-      checkbox.disabled = true;
-      delete checkbox.dataset.taskIndex;
-      return;
-    }
-
-    checkbox.disabled = false;
-    checkbox.dataset.taskIndex = String(idx);
-    checkbox.checked = raw.charAt(mapping.index).toLowerCase() === 'x';
-  });
-}
-
-function handlePreviewCheckboxChange(event) {
-  const target = event.target;
-  if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
-    return;
-  }
-
-  const { taskIndex } = target.dataset;
-  if (taskIndex === undefined) {
-    return;
-  }
-
-  const mappingIndex = Number(taskIndex);
-  if (!Number.isInteger(mappingIndex) || mappingIndex < 0) {
-    return;
-  }
-
-  const mapping = previewTaskCheckboxMappings[mappingIndex];
-  if (!mapping) {
-    return;
-  }
-
-  const newChar = target.checked ? 'x' : ' ';
-  const currentValue = editor.value;
-
-  if (currentValue.charAt(mapping.index).toLowerCase() === newChar) {
-    return;
-  }
-
-  const prevSelectionStart = editor.selectionStart;
-  const prevSelectionEnd = editor.selectionEnd;
-  const prevScrollTop = editor.scrollTop;
-
-  editor.value =
-    currentValue.slice(0, mapping.index) +
-    newChar +
-    currentValue.slice(mapping.index + 1);
-
-  editor.scrollTop = prevScrollTop;
-  editor.selectionStart = prevSelectionStart;
-  editor.selectionEnd = prevSelectionEnd;
-
-  extendEditorScrollSuppression();
-  const renderDuration = update();
-  extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
-  updateTOCHighlight();
-}
-
-function buildTOC() {
-  const raw = editor.value;
-  const slugCounts = {};
-  headingPositions = [];
-
-  // Collect heading lines while ignoring fenced code blocks
-  const lines = raw.split('\n');
-  let index = 0;
-  let inCode = false;
-  for (const line of lines) {
-    const fence = line.match(/^```/);
-    if (fence) {
-      inCode = !inCode;
-      index += line.length + 1;
-      continue;
-    }
-    if (!inCode) {
-      const m = line.match(/^(#{1,5})\s+(.*)$/);
-      if (m) {
-        const level = m[1].length;
-        const text = m[2].trim();
-        const base = text.toLowerCase().replace(/[^\w]+/g, '-');
-        const count = slugCounts[base] || 0;
-        slugCounts[base] = count + 1;
-        const id = count ? `${base}-${count}` : base;
-        headingPositions.push({ level, text, id, start: index });
-      }
-    }
-    index += line.length + 1;
-  }
-
-  const headingElements = Array.from(
-    preview.querySelectorAll('h1, h2, h3, h4, h5')
-  );
-  headingElements.forEach((h, i) => {
-    if (headingPositions[i]) {
-      h.id = headingPositions[i].id;
-    }
-  });
-
-  const root = document.createElement('ul');
-  const stack = [root];
-  let currentLevel = 1;
-
-  headingPositions.forEach(({ level, text, id }) => {
-    if (level > currentLevel) {
-      for (let i = currentLevel; i < level; i++) {
-        const ul = document.createElement('ul');
-        const lastLi = stack[stack.length - 1].lastElementChild;
-        if (lastLi) {
-          lastLi.appendChild(ul);
-        } else {
-          stack[stack.length - 1].appendChild(ul);
-        }
-        stack.push(ul);
-      }
-    } else if (level < currentLevel) {
-      for (let i = currentLevel; i > level; i--) {
-        stack.pop();
-      }
-    }
-
-    const li = document.createElement('li');
-    li.className = 'toc-item';
-    li.dataset.target = id;
-    li.textContent = text;
-    stack[stack.length - 1].appendChild(li);
-
-    currentLevel = level;
-  });
-
-  toc.innerHTML = '';
-  toc.appendChild(root);
-
-  tocItems = toc.querySelectorAll('.toc-item');
-  headings = headingElements;
-
-  tocItems.forEach(item => {
-    item.addEventListener('click', e => {
-      e.stopPropagation();
-      const target = document.getElementById(item.dataset.target);
-      if (target) {
-        const top =
-          target.getBoundingClientRect().top -
-          preview.getBoundingClientRect().top +
-          preview.scrollTop -
-          getHeaderOffset();
-        preview.scrollTo({ top, behavior: 'smooth' });
-        isPreviewManuallyPositioned = true;
-      }
-      const hp = headingPositions.find(h => h.id === item.dataset.target);
-      if (hp) {
-        editor.focus();
-        editor.selectionStart = editor.selectionEnd = hp.start;
+        update();
+        adjustTOCPosition();
         updateTOCHighlight();
+
+        const resetScrollPositions = () => {
+          editor.scrollTop = 0;
+          preview.scrollTop = 0;
+          if (toc) {
+            toc.scrollTop = 0;
+          }
+        };
+
+        resetScrollPositions();
+        requestAnimationFrame(resetScrollPositions);
+        isPreviewManuallyPositioned = false;
+      } catch (error) {
+        console.error(i18n.t('dialogs.templateLoadErrorLog'), error);
+        alert(i18n.t('dialogs.templateLoadErrorAlert'));
+      }
+    };
+
+    templateBtn.addEventListener('click', () => {
+      if (templateOptions.hidden) {
+        openTemplateMenu();
+      } else {
+        closeMenu();
       }
     });
+
+    templateBtn.addEventListener('keydown', event => {
+      if (
+        event.key === 'ArrowDown' ||
+        event.key === 'ArrowUp' ||
+        event.key === 'Enter' ||
+        event.key === ' ' ||
+        event.key === 'Spacebar'
+      ) {
+        event.preventDefault();
+        if (templateOptions.hidden) {
+          const startIndex =
+            event.key === 'ArrowUp' && templateButtons.length
+              ? templateButtons.length - 1
+              : 0;
+          openTemplateMenu(startIndex);
+        }
+      } else if (event.key === 'Escape' && !templateOptions.hidden) {
+        event.preventDefault();
+        closeMenu();
+      }
+    });
+
+    templateOptions.addEventListener('focusin', event => {
+      const option = event.target.closest('.template-option');
+      if (!option) return;
+      currentTemplateIndex = templateButtons.indexOf(option);
+    });
+
+    templateOptions.addEventListener('keydown', event => {
+      if (!templateButtons.length) return;
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          focusOption(currentTemplateIndex + 1);
+          break;
+        case 'ArrowUp':
+          event.preventDefault();
+          focusOption(currentTemplateIndex - 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          focusOption(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          focusOption(templateButtons.length - 1);
+          break;
+        case 'Escape':
+          event.preventDefault();
+          closeMenu();
+          templateBtn.focus();
+          break;
+        case 'Tab':
+          closeMenu();
+          break;
+        default:
+          break;
+      }
+    });
+
+    templateOptions.addEventListener('click', event => {
+      const option = event.target.closest('.template-option');
+      if (!option) return;
+      event.stopPropagation();
+      closeMenu();
+      applyTemplate(option.dataset.path);
+    });
+
+    document.addEventListener('click', event => {
+      if (
+        templateOptions.hidden ||
+        templateOptions.contains(event.target) ||
+        templateBtn.contains(event.target)
+      ) {
+        return;
+      }
+      closeMenu();
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && !templateOptions.hidden) {
+        closeMenu();
+        templateBtn.focus();
+      }
+    });
+
+    closeTemplateMenu = closeMenu;
+  }
+
+  document.addEventListener('i18n:change', () => {
+    updateDocumentTitle();
+    if (langSwitch) {
+      langSwitch.value = i18n.getCurrentLang();
+    }
+    if (templateBtn && templateOptions) {
+      closeTemplateMenu();
+      buildTemplateOptions();
+    }
   });
 
-  updateTOCHighlight();
-}
+  let headings = [];
+  let tocItems = [];
+  let headingPositions = [];
+  let previewTaskCheckboxMappings = [];
 
-function updateTOCHighlight() {
-  if (!headingPositions.length) return;
-  const pos = editor.selectionStart;
-  let currentId = headingPositions[0].id;
-  for (const hp of headingPositions) {
-    if (pos >= hp.start) {
-      currentId = hp.id;
-    } else {
-      break;
+  if (window.mermaid) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'loose',
+      flowchart: { htmlLabels: true }
+    });
+  }
+
+  function escapeHtml(str) {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  // Convert mermaid code fences to diagram containers
+  marked.use({
+    renderer: {
+      code(code, infostring, escaped) {
+        const lang = (infostring || '').trim().toLowerCase();
+        if (lang === 'mermaid') {
+          return `<div class="mermaid">${escapeHtml(code)}</div>`;
+        }
+        return false; // use default renderer
+      }
+    }
+  });
+
+  // Enable drag to resize panes
+  let isDraggingEditor = false;
+  let isDraggingTOC = false;
+
+  divider.addEventListener('mousedown', e => {
+    isDraggingEditor = true;
+    document.body.style.cursor = 'col-resize';
+    e.preventDefault();
+  });
+
+  tocDivider.addEventListener('mousedown', e => {
+    isDraggingTOC = true;
+    document.body.style.cursor = 'col-resize';
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', e => {
+    const rect = mainContainer.getBoundingClientRect();
+    const minWidth = 100;
+    if (isDraggingEditor) {
+      const tocWidth = toc.offsetWidth + tocDivider.offsetWidth;
+      const dividerWidth = divider.offsetWidth;
+      let newEditorWidth = e.clientX - rect.left - tocWidth;
+      const maxWidth = rect.width - tocWidth - dividerWidth - minWidth;
+      if (newEditorWidth < minWidth) newEditorWidth = minWidth;
+      if (newEditorWidth > maxWidth) newEditorWidth = maxWidth;
+      editor.style.width = `${newEditorWidth}px`;
+    } else if (isDraggingTOC) {
+      const dividerWidth = tocDivider.offsetWidth;
+      let newTocWidth = e.clientX - rect.left;
+      const maxWidth = rect.width - dividerWidth - divider.offsetWidth - editor.offsetWidth - minWidth;
+      if (newTocWidth < minWidth) newTocWidth = minWidth;
+      if (newTocWidth > maxWidth) newTocWidth = maxWidth;
+      toc.style.width = `${newTocWidth}px`;
+    }
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (isDraggingEditor || isDraggingTOC) {
+      isDraggingEditor = false;
+      isDraggingTOC = false;
+      document.body.style.cursor = '';
+    }
+  });
+
+  // Flags to avoid recursive scroll events
+  let isSyncingEditorScroll = false;
+  let isSyncingPreviewScroll = false;
+  let editorScrollSuppressUntil = 0;
+  let previewScrollSuppressUntil = 0;
+  const INPUT_SCROLL_SUPPRESS_DURATION = 400;
+  const PREVIEW_RENDER_SCROLL_SUPPRESS_DURATION = 400;
+  const MANUAL_SCROLL_INTENT_DURATION = 1200;
+  let editorManualScrollIntentUntil = 0;
+  let isEditorScrollbarDragActive = false;
+  let isPreviewManuallyPositioned = false;
+
+  function extendEditorScrollSuppression(duration = INPUT_SCROLL_SUPPRESS_DURATION) {
+    const targetTime = performance.now() + duration;
+    if (targetTime > editorScrollSuppressUntil) {
+      editorScrollSuppressUntil = targetTime;
+    }
+    if (!isEditorScrollbarDragActive) {
+      editorManualScrollIntentUntil = 0;
     }
   }
-  tocItems.forEach(item => {
-    item.classList.toggle('active', item.dataset.target === currentId);
+
+  function getHeaderOffset() {
+    return toolbar ? toolbar.offsetHeight : 0;
+  }
+
+  function registerEditorScrollIntent(duration = MANUAL_SCROLL_INTENT_DURATION) {
+    if (duration === Infinity) {
+      editorManualScrollIntentUntil = Infinity;
+      return;
+    }
+
+    if (editorManualScrollIntentUntil === Infinity) {
+      return;
+    }
+
+    const targetTime = performance.now() + duration;
+    if (targetTime > editorManualScrollIntentUntil) {
+      editorManualScrollIntentUntil = targetTime;
+    }
+  }
+
+  function adjustTOCPosition() {
+    const offset = getHeaderOffset();
+    document.documentElement.style.setProperty('--header-offset', offset + 'px');
+  }
+
+  window.addEventListener('load', adjustTOCPosition);
+  window.addEventListener('resize', adjustTOCPosition);
+
+  function syncScroll(source, target) {
+    const sourceMax = source.scrollHeight - source.clientHeight;
+    const targetMax = target.scrollHeight - target.clientHeight;
+    if (sourceMax <= 0 || targetMax <= 0) return;
+    const ratio = source.scrollTop / sourceMax;
+    target.scrollTop = ratio * targetMax;
+  }
+
+  editor.addEventListener('scroll', () => {
+    const now = performance.now();
+    if (isSyncingEditorScroll) {
+      isSyncingEditorScroll = false;
+      return;
+    }
+
+    const hasManualIntent =
+      editorManualScrollIntentUntil === Infinity ||
+      now < editorManualScrollIntentUntil;
+
+    if (!hasManualIntent) {
+      return;
+    }
+
+    if (now < editorScrollSuppressUntil || now < previewScrollSuppressUntil) {
+      return;
+    }
+
+    if (isPreviewManuallyPositioned) {
+      return;
+    }
+
+    isSyncingPreviewScroll = true;
+    syncScroll(editor, preview);
+    isSyncingEditorScroll = false;
   });
-}
 
-// Base64格納用マップ
-const imageMap = {};
+  preview.addEventListener('scroll', () => {
+    if (isSyncingPreviewScroll) {
+      isSyncingPreviewScroll = false;
+      return;
+    }
 
-editor.addEventListener('beforeinput', () => {
-  extendEditorScrollSuppression();
-});
+    if (performance.now() < previewScrollSuppressUntil) {
+      return;
+    }
 
-editor.addEventListener('input', () => {
-  extendEditorScrollSuppression();
-  const renderDuration = update();
-  extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
-  updateTOCHighlight();
-});
+    isSyncingEditorScroll = true;
+    syncScroll(preview, editor);
+  });
 
-editor.addEventListener('compositionstart', extendEditorScrollSuppression);
-editor.addEventListener('compositionupdate', extendEditorScrollSuppression);
-editor.addEventListener('compositionend', extendEditorScrollSuppression);
-
-const registerPreviewManualInteraction = () => {
-  previewScrollSuppressUntil = 0;
-  isPreviewManuallyPositioned = true;
-};
-
-preview.addEventListener('wheel', registerPreviewManualInteraction, { passive: true });
-preview.addEventListener('touchmove', registerPreviewManualInteraction, {
-  passive: true,
-});
-preview.addEventListener('touchstart', registerPreviewManualInteraction, {
-  passive: true,
-});
-preview.addEventListener('pointerdown', event => {
-  if (event.pointerType !== 'mouse' || event.button !== 0) return;
-  const rect = preview.getBoundingClientRect();
-  if (event.clientX >= rect.right - 20) {
-    registerPreviewManualInteraction();
-  }
-});
-preview.addEventListener('change', handlePreviewCheckboxChange);
-
-const registerEditorManualInteraction = () => {
-  registerEditorScrollIntent();
-  editorScrollSuppressUntil = 0;
-  previewScrollSuppressUntil = 0;
-  isPreviewManuallyPositioned = false;
-};
-
-editor.addEventListener('wheel', registerEditorManualInteraction, { passive: true });
-editor.addEventListener('touchmove', registerEditorManualInteraction, {
-  passive: true,
-});
-editor.addEventListener('touchstart', registerEditorManualInteraction, {
-  passive: true,
-});
-editor.addEventListener('pointerdown', event => {
-  if (event.pointerType !== 'mouse' || event.button !== 0) return;
-  const rect = editor.getBoundingClientRect();
-  if (event.clientX >= rect.right - 20) {
-    isEditorScrollbarDragActive = true;
-    registerEditorScrollIntent(Infinity);
-    registerEditorManualInteraction();
-  }
-});
-editor.addEventListener('blur', () => {
-  if (!isEditorScrollbarDragActive && editorManualScrollIntentUntil !== Infinity) {
-    editorManualScrollIntentUntil = 0;
-  }
-});
-document.addEventListener('pointerup', event => {
-  if (event.pointerType !== 'mouse' || !isEditorScrollbarDragActive) {
-    return;
-  }
-  isEditorScrollbarDragActive = false;
-  if (editorManualScrollIntentUntil === Infinity) {
-    editorManualScrollIntentUntil =
-      performance.now() + MANUAL_SCROLL_INTENT_DURATION;
-  }
-});
-document.addEventListener('pointercancel', event => {
-  if (event.pointerType !== 'mouse' || !isEditorScrollbarDragActive) {
-    return;
-  }
-  isEditorScrollbarDragActive = false;
-  if (editorManualScrollIntentUntil === Infinity) {
-    editorManualScrollIntentUntil = 0;
-  }
-});
-
-function continueListOnEnter(event) {
-  if (
-    event.key !== 'Enter' ||
-    event.shiftKey ||
-    event.altKey ||
-    event.ctrlKey ||
-    event.metaKey ||
-    event.isComposing
-  ) {
-    return false;
+  // Update preview and expand stored Base64 images
+  function clampPreviewScrollTop(value) {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    const maxScrollTop = Math.max(0, preview.scrollHeight - preview.clientHeight);
+    if (maxScrollTop <= 0) {
+      return 0;
+    }
+    if (value <= 0) {
+      return 0;
+    }
+    return Math.min(value, maxScrollTop);
   }
 
-  const { selectionStart, selectionEnd, value } = editor;
-
-  if (selectionStart !== selectionEnd) {
-    return false;
+  function restorePreviewScrollPosition(targetScrollTop) {
+    const clamped = clampPreviewScrollTop(targetScrollTop);
+    const prevSuppressUntil = previewScrollSuppressUntil;
+    previewScrollSuppressUntil = Math.max(prevSuppressUntil, performance.now() + 50);
+    isSyncingPreviewScroll = true;
+    preview.scrollTop = clamped;
+    isSyncingPreviewScroll = false;
   }
 
-  const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
-  const beforeCursor = value.slice(lineStart, selectionStart);
-  const listMatch = beforeCursor.match(
-    /^(\s*)([*+-]|\d+[.)])\s+(\[(?: |x|X)\]\s*)?/
-  );
+  function update() {
+    const renderStart = performance.now();
+    const raw = editor.value;
+    const previousScrollTop = preview.scrollTop;
 
-  if (!listMatch) {
-    return false;
+    // Expand <!-- image:filename --> ... <!-- /image --> placeholders
+    const expanded = raw.replace(/<!-- image:(.*?) -->[\s\S]*?<!-- \/image -->/g, (match, filename) => {
+      const trimmedFilename = filename.trim();
+      const matchBase64 = imageMap[trimmedFilename];
+      if (matchBase64) {
+        return `![${trimmedFilename}](${matchBase64})`;
+      }
+      return i18n.t('image.fallback', { filename: trimmedFilename });
+    });
+
+    preview.innerHTML = marked.parse(expanded, { breaks: true, mangle: false });
+    updatePreviewTaskCheckboxes(raw);
+
+    // Fallback: convert any remaining mermaid code blocks after parsing
+    preview.querySelectorAll('pre code.language-mermaid').forEach(block => {
+      const pre = block.parentElement;
+      const div = document.createElement('div');
+      div.className = 'mermaid';
+      div.textContent = block.textContent;
+      pre.replaceWith(div);
+    });
+
+    if (window.mermaid) {
+      try {
+        const nodes = preview.querySelectorAll('.mermaid');
+        if (mermaid.run) {
+          mermaid.run({ nodes });
+        } else if (mermaid.init) {
+          mermaid.init(undefined, nodes);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    buildTOC();
+
+    const renderEnd = performance.now();
+    const renderDuration = renderEnd - renderStart;
+    previewScrollSuppressUntil =
+      renderEnd +
+      Math.max(PREVIEW_RENDER_SCROLL_SUPPRESS_DURATION, renderDuration);
+
+    const restore = () => restorePreviewScrollPosition(previousScrollTop);
+    restore();
+    requestAnimationFrame(restore);
+    requestAnimationFrame(() => requestAnimationFrame(restore));
+
+    return renderDuration;
   }
 
-  const nextNewlineIndex = value.indexOf('\n', selectionEnd);
-  const afterCursorWithinLine =
-    nextNewlineIndex === -1
-      ? value.slice(selectionEnd)
-      : value.slice(selectionEnd, nextNewlineIndex);
-  const fullLineContent = beforeCursor + afterCursorWithinLine;
-  const contentAfterMarker = fullLineContent.slice(listMatch[0].length);
+  function updatePreviewTaskCheckboxes(raw) {
+    previewTaskCheckboxMappings = [];
+    const lines = raw.split('\n');
+    let index = 0;
+    let inCode = false;
+    const taskPattern = /^(\s*)(?:[*+-]|\d+[.)])\s+\[( |x|X)\]/;
 
-  if (!contentAfterMarker.trim()) {
-    return false;
+    for (const line of lines) {
+      const fence = line.match(/^```/);
+      if (fence) {
+        inCode = !inCode;
+        index += line.length + 1;
+        continue;
+      }
+
+      if (!inCode && taskPattern.test(line)) {
+        const bracketIndex = line.indexOf('[');
+        if (bracketIndex !== -1) {
+          previewTaskCheckboxMappings.push({ index: index + bracketIndex + 1 });
+        }
+      }
+
+      index += line.length + 1;
+    }
+
+    const checkboxes = preview.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach((checkbox, idx) => {
+      const mapping = previewTaskCheckboxMappings[idx];
+      if (!mapping) {
+        checkbox.disabled = true;
+        delete checkbox.dataset.taskIndex;
+        return;
+      }
+
+      checkbox.disabled = false;
+      checkbox.dataset.taskIndex = String(idx);
+      checkbox.checked = raw.charAt(mapping.index).toLowerCase() === 'x';
+    });
   }
 
-  event.preventDefault();
-  extendEditorScrollSuppression();
+  function handlePreviewCheckboxChange(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
+      return;
+    }
 
-  const indent = listMatch[1] || '';
-  const marker = listMatch[2];
-  const hasCheckbox = Boolean(listMatch[3]);
-  const orderedMatch = marker.match(/^(\d+)([.)])$/);
-  let nextMarker = marker;
-  if (orderedMatch) {
-    const nextNumber = Number(orderedMatch[1]) + 1;
-    nextMarker = `${nextNumber}${orderedMatch[2]}`;
-  }
+    const { taskIndex } = target.dataset;
+    if (taskIndex === undefined) {
+      return;
+    }
 
-  let remainder = value.slice(selectionEnd);
-  if (remainder.startsWith(' ')) {
-    remainder = remainder.slice(1);
-  }
+    const mappingIndex = Number(taskIndex);
+    if (!Number.isInteger(mappingIndex) || mappingIndex < 0) {
+      return;
+    }
 
-  const checkboxSegment = hasCheckbox ? '[ ] ' : '';
-  const insertion = `\n${indent}${nextMarker} ${checkboxSegment}`;
-  const newValue =
-    value.slice(0, selectionStart) + insertion + remainder;
+    const mapping = previewTaskCheckboxMappings[mappingIndex];
+    if (!mapping) {
+      return;
+    }
 
-  const newCursorPos = selectionStart + insertion.length;
-  const prevScrollTop = editor.scrollTop;
+    const newChar = target.checked ? 'x' : ' ';
+    const currentValue = editor.value;
 
-  editor.value = newValue;
-  editor.scrollTop = prevScrollTop;
-  editor.selectionStart = editor.selectionEnd = newCursorPos;
+    if (currentValue.charAt(mapping.index).toLowerCase() === newChar) {
+      return;
+    }
 
-  const renderDuration = update();
-  extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
-  updateTOCHighlight();
+    const prevSelectionStart = editor.selectionStart;
+    const prevSelectionEnd = editor.selectionEnd;
+    const prevScrollTop = editor.scrollTop;
 
-  return true;
-}
-editor.addEventListener('keydown', event => {
-  if (
-    event.key === 'PageDown' ||
-    event.key === 'PageUp' ||
-    event.key === 'Home' ||
-    event.key === 'End' ||
-    ((event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
-      (event.metaKey || event.ctrlKey))
-  ) {
-    registerEditorManualInteraction();
-    return;
-  }
-
-  if (continueListOnEnter(event)) {
-    return;
-  }
-
-  extendEditorScrollSuppression();
-});
-editor.addEventListener('keyup', updateTOCHighlight);
-editor.addEventListener('click', updateTOCHighlight);
-window.addEventListener('load', update);
-
-imageInput.addEventListener('change', event => {
-  const file = event.target.files[0];
-  if (!file) return;
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    const base64 = reader.result;
-    const filename = file.name;
-    imageMap[filename] = base64;
-
-    const markdownImage =
-      `\n<!-- image:${filename} -->\n[画像: ${filename}]\n<!-- /image -->\n`;
-    const cursorPos = editor.selectionStart;
     editor.value =
-      editor.value.slice(0, cursorPos) + markdownImage + editor.value.slice(cursorPos);
+      currentValue.slice(0, mapping.index) +
+      newChar +
+      currentValue.slice(mapping.index + 1);
 
-    update();
-  };
-  reader.readAsDataURL(file);
-});
+    editor.scrollTop = prevScrollTop;
+    editor.selectionStart = prevSelectionStart;
+    editor.selectionEnd = prevSelectionEnd;
 
-exportPdfBtn.addEventListener('click', () => {
-  const win = window.open('', '', 'width=800,height=600');
-  const cssHref = document.querySelector('link[rel="stylesheet"]').href;
-  win.document.write(`<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Preview</title><link rel="stylesheet" href="${cssHref}"></head><body>${preview.innerHTML}</body></html>`);
-  win.document.close();
-  win.onload = () => {
-    win.focus();
-    win.print();
-    win.close();
-  };
-});
-
-saveMdBtn.addEventListener('click', () => {
-  const filename = prompt('保存するファイル名を入力してください', 'document.md');
-  if (filename) {
-    const blob = new Blob([editor.value], { type: 'text/markdown' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename.endsWith('.md') ? filename : `${filename}.md`;
-    a.click();
-    URL.revokeObjectURL(url);
+    extendEditorScrollSuppression();
+    const renderDuration = update();
+    extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
+    updateTOCHighlight();
   }
-});
 
-helpBtn.addEventListener('click', () => {
-  helpWindow.classList.toggle('hidden');
-});
+  function buildTOC() {
+    const raw = editor.value;
+    const slugCounts = {};
+    headingPositions = [];
 
-helpClose.addEventListener('click', () => {
-  helpWindow.classList.add('hidden');
-});
+    // Collect heading lines while ignoring fenced code blocks
+    const lines = raw.split('\n');
+    let index = 0;
+    let inCode = false;
+    for (const line of lines) {
+      const fence = line.match(/^```/);
+      if (fence) {
+        inCode = !inCode;
+        index += line.length + 1;
+        continue;
+      }
+      if (!inCode) {
+        const m = line.match(/^(#{1,5})\s+(.*)$/);
+        if (m) {
+          const level = m[1].length;
+          const text = m[2].trim();
+          const base = text.toLowerCase().replace(/[^\w]+/g, '-');
+          const count = slugCounts[base] || 0;
+          slugCounts[base] = count + 1;
+          const id = count ? `${base}-${count}` : base;
+          headingPositions.push({ level, text, id, start: index });
+        }
+      }
+      index += line.length + 1;
+    }
+
+    const headingElements = Array.from(
+      preview.querySelectorAll('h1, h2, h3, h4, h5')
+    );
+    headingElements.forEach((h, i) => {
+      if (headingPositions[i]) {
+        h.id = headingPositions[i].id;
+      }
+    });
+
+    const root = document.createElement('ul');
+    const stack = [root];
+    let currentLevel = 1;
+
+    headingPositions.forEach(({ level, text, id }) => {
+      if (level > currentLevel) {
+        for (let i = currentLevel; i < level; i++) {
+          const ul = document.createElement('ul');
+          const lastLi = stack[stack.length - 1].lastElementChild;
+          if (lastLi) {
+            lastLi.appendChild(ul);
+          } else {
+            stack[stack.length - 1].appendChild(ul);
+          }
+          stack.push(ul);
+        }
+      } else if (level < currentLevel) {
+        for (let i = currentLevel; i > level; i--) {
+          stack.pop();
+        }
+      }
+
+      const li = document.createElement('li');
+      li.className = 'toc-item';
+      li.dataset.target = id;
+      li.textContent = text;
+      stack[stack.length - 1].appendChild(li);
+
+      currentLevel = level;
+    });
+
+    toc.innerHTML = '';
+    toc.appendChild(root);
+
+    tocItems = toc.querySelectorAll('.toc-item');
+    headings = headingElements;
+
+    tocItems.forEach(item => {
+      item.addEventListener('click', e => {
+        e.stopPropagation();
+        const target = document.getElementById(item.dataset.target);
+        if (target) {
+          const top =
+            target.getBoundingClientRect().top -
+            preview.getBoundingClientRect().top +
+            preview.scrollTop -
+            getHeaderOffset();
+          preview.scrollTo({ top, behavior: 'smooth' });
+          isPreviewManuallyPositioned = true;
+        }
+        const hp = headingPositions.find(h => h.id === item.dataset.target);
+        if (hp) {
+          editor.focus();
+          editor.selectionStart = editor.selectionEnd = hp.start;
+          updateTOCHighlight();
+        }
+      });
+    });
+
+    updateTOCHighlight();
+  }
+
+  function updateTOCHighlight() {
+    if (!headingPositions.length) return;
+    const pos = editor.selectionStart;
+    let currentId = headingPositions[0].id;
+    for (const hp of headingPositions) {
+      if (pos >= hp.start) {
+        currentId = hp.id;
+      } else {
+        break;
+      }
+    }
+    tocItems.forEach(item => {
+      item.classList.toggle('active', item.dataset.target === currentId);
+    });
+  }
+
+  // Map for storing Base64-encoded images
+  const imageMap = {};
+
+  editor.addEventListener('beforeinput', () => {
+    extendEditorScrollSuppression();
+  });
+
+  editor.addEventListener('input', () => {
+    extendEditorScrollSuppression();
+    const renderDuration = update();
+    extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
+    updateTOCHighlight();
+  });
+
+  editor.addEventListener('compositionstart', extendEditorScrollSuppression);
+  editor.addEventListener('compositionupdate', extendEditorScrollSuppression);
+  editor.addEventListener('compositionend', extendEditorScrollSuppression);
+
+  const registerPreviewManualInteraction = () => {
+    previewScrollSuppressUntil = 0;
+    isPreviewManuallyPositioned = true;
+  };
+
+  preview.addEventListener('wheel', registerPreviewManualInteraction, { passive: true });
+  preview.addEventListener('touchmove', registerPreviewManualInteraction, {
+    passive: true,
+  });
+  preview.addEventListener('touchstart', registerPreviewManualInteraction, {
+    passive: true,
+  });
+  preview.addEventListener('pointerdown', event => {
+    if (event.pointerType !== 'mouse' || event.button !== 0) return;
+    const rect = preview.getBoundingClientRect();
+    if (event.clientX >= rect.right - 20) {
+      registerPreviewManualInteraction();
+    }
+  });
+  preview.addEventListener('change', handlePreviewCheckboxChange);
+
+  const registerEditorManualInteraction = () => {
+    registerEditorScrollIntent();
+    editorScrollSuppressUntil = 0;
+    previewScrollSuppressUntil = 0;
+    isPreviewManuallyPositioned = false;
+  };
+
+  editor.addEventListener('wheel', registerEditorManualInteraction, { passive: true });
+  editor.addEventListener('touchmove', registerEditorManualInteraction, {
+    passive: true,
+  });
+  editor.addEventListener('touchstart', registerEditorManualInteraction, {
+    passive: true,
+  });
+  editor.addEventListener('pointerdown', event => {
+    if (event.pointerType !== 'mouse' || event.button !== 0) return;
+    const rect = editor.getBoundingClientRect();
+    if (event.clientX >= rect.right - 20) {
+      isEditorScrollbarDragActive = true;
+      registerEditorScrollIntent(Infinity);
+      registerEditorManualInteraction();
+    }
+  });
+  editor.addEventListener('blur', () => {
+    if (!isEditorScrollbarDragActive && editorManualScrollIntentUntil !== Infinity) {
+      editorManualScrollIntentUntil = 0;
+    }
+  });
+  document.addEventListener('pointerup', event => {
+    if (event.pointerType !== 'mouse' || !isEditorScrollbarDragActive) {
+      return;
+    }
+    isEditorScrollbarDragActive = false;
+    if (editorManualScrollIntentUntil === Infinity) {
+      editorManualScrollIntentUntil =
+        performance.now() + MANUAL_SCROLL_INTENT_DURATION;
+    }
+  });
+  document.addEventListener('pointercancel', event => {
+    if (event.pointerType !== 'mouse' || !isEditorScrollbarDragActive) {
+      return;
+    }
+    isEditorScrollbarDragActive = false;
+    if (editorManualScrollIntentUntil === Infinity) {
+      editorManualScrollIntentUntil = 0;
+    }
+  });
+
+  function continueListOnEnter(event) {
+    if (
+      event.key !== 'Enter' ||
+      event.shiftKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.isComposing
+    ) {
+      return false;
+    }
+
+    const { selectionStart, selectionEnd, value } = editor;
+
+    if (selectionStart !== selectionEnd) {
+      return false;
+    }
+
+    const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+    const beforeCursor = value.slice(lineStart, selectionStart);
+    const listMatch = beforeCursor.match(
+      /^(\s*)([*+-]|\d+[.)])\s+(\[(?: |x|X)\]\s*)?/
+    );
+
+    if (!listMatch) {
+      return false;
+    }
+
+    const nextNewlineIndex = value.indexOf('\n', selectionEnd);
+    const afterCursorWithinLine =
+      nextNewlineIndex === -1
+        ? value.slice(selectionEnd)
+        : value.slice(selectionEnd, nextNewlineIndex);
+    const fullLineContent = beforeCursor + afterCursorWithinLine;
+    const contentAfterMarker = fullLineContent.slice(listMatch[0].length);
+
+    if (!contentAfterMarker.trim()) {
+      return false;
+    }
+
+    event.preventDefault();
+    extendEditorScrollSuppression();
+
+    const indent = listMatch[1] || '';
+    const marker = listMatch[2];
+    const hasCheckbox = Boolean(listMatch[3]);
+    const orderedMatch = marker.match(/^(\d+)([.)])$/);
+    let nextMarker = marker;
+    if (orderedMatch) {
+      const nextNumber = Number(orderedMatch[1]) + 1;
+      nextMarker = `${nextNumber}${orderedMatch[2]}`;
+    }
+
+    let remainder = value.slice(selectionEnd);
+    if (remainder.startsWith(' ')) {
+      remainder = remainder.slice(1);
+    }
+
+    const checkboxSegment = hasCheckbox ? '[ ] ' : '';
+    const insertion = `\n${indent}${nextMarker} ${checkboxSegment}`;
+    const newValue =
+      value.slice(0, selectionStart) + insertion + remainder;
+
+    const newCursorPos = selectionStart + insertion.length;
+    const prevScrollTop = editor.scrollTop;
+
+    editor.value = newValue;
+    editor.scrollTop = prevScrollTop;
+    editor.selectionStart = editor.selectionEnd = newCursorPos;
+
+    const renderDuration = update();
+    extendEditorScrollSuppression(renderDuration + INPUT_SCROLL_SUPPRESS_DURATION);
+    updateTOCHighlight();
+
+    return true;
+  }
+  editor.addEventListener('keydown', event => {
+    if (
+      event.key === 'PageDown' ||
+      event.key === 'PageUp' ||
+      event.key === 'Home' ||
+      event.key === 'End' ||
+      ((event.key === 'ArrowDown' || event.key === 'ArrowUp') &&
+        (event.metaKey || event.ctrlKey))
+    ) {
+      registerEditorManualInteraction();
+      return;
+    }
+
+    if (continueListOnEnter(event)) {
+      return;
+    }
+
+    extendEditorScrollSuppression();
+  });
+  editor.addEventListener('keyup', updateTOCHighlight);
+  editor.addEventListener('click', updateTOCHighlight);
+  window.addEventListener('load', update);
+
+  imageInput.addEventListener('change', event => {
+    const file = event.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+    const base64 = reader.result;
+    const filename = file.name.trim();
+      imageMap[filename] = base64;
+
+      const markdownImage = i18n.t('image.markdownTemplate', { filename });
+      const cursorPos = editor.selectionStart;
+      editor.value =
+        editor.value.slice(0, cursorPos) + markdownImage + editor.value.slice(cursorPos);
+
+      update();
+    };
+    reader.readAsDataURL(file);
+  });
+
+  exportPdfBtn.addEventListener('click', () => {
+    const win = window.open('', '', 'width=800,height=600');
+    if (!win) {
+      return;
+    }
+    const cssHref = document.querySelector('link[rel="stylesheet"]').href;
+    const previewTitle = i18n.t('dialogs.previewTitle');
+    const langAttr =
+      document.documentElement.getAttribute('lang') || i18n.getCurrentLang();
+    win.document.write(
+      `<!DOCTYPE html><html lang="${langAttr}"><head><meta charset="UTF-8"><title>${previewTitle}</title><link rel="stylesheet" href="${cssHref}"></head><body>${preview.innerHTML}</body></html>`
+    );
+    win.document.close();
+    win.onload = () => {
+      win.focus();
+      win.print();
+      win.close();
+    };
+  });
+
+  saveMdBtn.addEventListener('click', () => {
+    const filename = prompt(
+      i18n.t('dialogs.saveFilenamePrompt'),
+      i18n.t('dialogs.defaultFileName')
+    );
+    if (filename) {
+      const blob = new Blob([editor.value], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename.endsWith('.md') ? filename : `${filename}.md`;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+  });
+
+  helpBtn.addEventListener('click', () => {
+    helpWindow.classList.toggle('hidden');
+  });
+
+  helpClose.addEventListener('click', () => {
+    helpWindow.classList.add('hidden');
+  });
+
+}
 

--- a/style.css
+++ b/style.css
@@ -44,6 +44,25 @@ body {
   transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
+#lang-label {
+  font-weight: 500;
+  color: #003366;
+}
+
+#lang-switch {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #aac8ff;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #003366;
+  font-size: 0.9rem;
+}
+
+#lang-switch:focus-visible {
+  outline: 2px solid #002d6c;
+  outline-offset: 2px;
+}
+
 .toolbar-button:hover,
 .toolbar-button:focus-visible {
   background: #004488;


### PR DESCRIPTION
## Summary
- add an i18n module with configurable default language and English/Japanese dictionaries
- update the UI markup and styles to expose translation keys and a language selector
- integrate the editor logic with the new translations, including localized dialogs and exports

## Testing
- npm test *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf59a4abbc832fb47f5e0792e3eea5