### PR TITLE
Fix code block indentation in preview

### DIFF
--- a/style.css
+++ b/style.css
@@ -219,6 +219,13 @@ code {
   color: #003366;
 }
 
+pre code {
+  display: block;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
 #help-window {
   position: fixed;
   bottom: 1rem;


### PR DESCRIPTION
## Summary
- ensure multiline code blocks in the preview retain consistent indentation by resetting padding/background on `pre code`

## Testing
- `npm test` *(fails: missing Playwright browsers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa88b3c4c832fb7ccfe202b044170