### PR TITLE
Adjust file open/save flows to remove confirmation dialogs

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,15 +68,6 @@ function startApp() {
         return;
       }
 
-      const shouldReplace =
-        !editor.value.trim() ||
-        confirm(i18n.t('dialogs.replaceFile'));
-
-      if (!shouldReplace) {
-        markdownInput.value = '';
-        return;
-      }
-
       const reader = new FileReader();
 
       reader.onload = loadEvent => {
@@ -1036,19 +1027,20 @@ function startApp() {
   });
 
   saveMdBtn.addEventListener('click', () => {
-    const filename = prompt(
-      i18n.t('dialogs.saveFilenamePrompt'),
-      i18n.t('dialogs.defaultFileName')
-    );
-    if (filename) {
-      const blob = new Blob([editor.value], { type: 'text/markdown' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = filename.endsWith('.md') ? filename : `${filename}.md`;
-      a.click();
-      URL.revokeObjectURL(url);
-    }
+    const defaultName = i18n.t('dialogs.defaultFileName');
+    const trimmedName =
+      typeof defaultName === 'string' && defaultName.trim()
+        ? defaultName.trim()
+        : 'document.md';
+    const filename = trimmedName.endsWith('.md') ? trimmedName : `${trimmedName}.md`;
+
+    const blob = new Blob([editor.value], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
   });
 
   helpBtn.addEventListener('click', () => {

--- a/tests/actions.spec.js
+++ b/tests/actions.spec.js
@@ -56,13 +56,11 @@ test('divider can move horizontally', async ({ page }) => {
 
 test('saves markdown to file', async ({ page }) => {
   await page.goto(fileUrl);
-  const filename = 'testfile.md';
-  page.once('dialog', dialog => dialog.accept(filename));
   const [download] = await Promise.all([
     page.waitForEvent('download'),
     page.click('#save-md'),
   ]);
-  expect(download.suggestedFilename()).toBe(filename);
+  expect(download.suggestedFilename()).toBe('document.md');
 });
 
 test('opens markdown file into editor', async ({ page }) => {
@@ -71,7 +69,6 @@ test('opens markdown file into editor', async ({ page }) => {
     page.waitForEvent('filechooser'),
     page.click('#open-md'),
   ]);
-  page.once('dialog', dialog => dialog.accept());
   await fileChooser.setFiles({
     name: 'opened.md',
     mimeType: 'text/markdown',


### PR DESCRIPTION
## Summary
- remove the confirmation prompt when opening a markdown file so the selected file loads immediately
- update the save action to skip the filename prompt and trigger the browser save dialog with the default name
- align Playwright tests with the new behaviors

## Testing
- `npm test` *(fails: Playwright browsers could not be installed due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cfac12a1b4832f95e5746b8532bad7