### PR TITLE
Add bold formatting context menu to editor

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -54,6 +54,9 @@
         mermaidCheatsheet:
           '```mermaid\ngraph TD\n  A[Start] --> B{Condition}\n  B -->|Yes| C[Process 1]\n  B -->|No| D[Process 2]\n```'
       },
+      formatting: {
+        bold: '𝐁 Bold'
+      },
       image: {
         fallback: '[Image: {filename}]',
         markdownTemplate:
@@ -110,6 +113,9 @@
         mermaidTitle: 'Mermaid チートシート',
         mermaidCheatsheet:
           '```mermaid\ngraph TD\n  A[開始] --> B{条件}\n  B -->|はい| C[処理1]\n  B -->|いいえ| D[処理2]\n```'
+      },
+      formatting: {
+        bold: '太字'
       },
       image: {
         fallback: '[画像: {filename}]',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -45,6 +45,9 @@
     "mermaidTitle": "Mermaid Cheat Sheet",
     "mermaidCheatsheet": "```mermaid\ngraph TD\n  A[Start] --> B{Condition}\n  B -->|Yes| C[Process 1]\n  B -->|No| D[Process 2]\n```"
   },
+  "formatting": {
+    "bold": "𝐁 Bold"
+  },
   "image": {
     "fallback": "[Image: {filename}]",
     "markdownTemplate": "\n<!-- image:{filename} -->\n[Image: {filename}]\n<!-- /image -->\n"

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -45,6 +45,9 @@
     "mermaidTitle": "Mermaid チートシート",
     "mermaidCheatsheet": "```mermaid\ngraph TD\n  A[開始] --> B{条件}\n  B -->|はい| C[処理1]\n  B -->|いいえ| D[処理2]\n```"
   },
+  "formatting": {
+    "bold": "太字"
+  },
   "image": {
     "fallback": "[画像: {filename}]",
     "markdownTemplate": "\n<!-- image:{filename} -->\n[画像: {filename}]\n<!-- /image -->\n"

--- a/script.js
+++ b/script.js
@@ -554,12 +554,12 @@ function startApp() {
     if (!formattingBoldButton) {
       return;
     }
-    const selectionLength = getEditorSelectionLength();
-    formattingBoldButton.disabled = selectionLength === 0;
-    formattingBoldButton.setAttribute(
-      'aria-disabled',
-      selectionLength === 0 ? 'true' : 'false'
-    );
+    if (formattingBoldButton.disabled) {
+      formattingBoldButton.disabled = false;
+    }
+    if (formattingBoldButton.getAttribute('aria-disabled') !== null) {
+      formattingBoldButton.removeAttribute('aria-disabled');
+    }
   }
 
   function hideFormattingMenu() {

--- a/script.js
+++ b/script.js
@@ -712,7 +712,15 @@ function startApp() {
     }
   }
 
-  function handleEditorBlur() {
+  function handleEditorBlur(event) {
+    if (
+      formattingMenuElement &&
+      event &&
+      event.relatedTarget &&
+      formattingMenuElement.contains(event.relatedTarget)
+    ) {
+      return;
+    }
     hideFormattingMenu();
   }
 

--- a/style.css
+++ b/style.css
@@ -115,6 +115,52 @@ body {
   outline: none;
 }
 
+#formatting-menu {
+  position: absolute;
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  background: #ffffff;
+  border: 1px solid #aac8ff;
+  border-radius: 6px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  min-width: 140px;
+  z-index: 1500;
+}
+
+#formatting-menu.visible {
+  display: flex;
+}
+
+.formatting-menu-button {
+  background: transparent;
+  border: none;
+  color: #003366;
+  font-size: 0.9rem;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.formatting-menu-button:hover,
+.formatting-menu-button:focus-visible {
+  background: #e6f0ff;
+  outline: none;
+}
+
+.formatting-menu-button:disabled {
+  cursor: default;
+  opacity: 0.6;
+  background: transparent;
+}
+
+.formatting-menu-button:disabled:hover,
+.formatting-menu-button:disabled:focus-visible {
+  background: transparent;
+}
+
 main {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## Summary
- add a floating formatting context menu to the editor that appears on selection or right-click and applies bold formatting
- add styling for the formatting menu and provide English/Japanese translations for the bold action
- update editor event handlers so the menu closes appropriately and formatting updates the stored text

## Testing
- npm test *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c99e4dc4832f977b663c5f12e10c