### PR TITLE
Fix editor overlap by sizing text panels with border-box

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,6 +181,7 @@ main {
   width: 100%;
   height: 100%;
   padding: 1rem;
+  box-sizing: border-box;
   border: none;
   resize: none;
   font-size: 1rem;
@@ -227,6 +228,7 @@ main {
   flex: 1;
   height: 100%;
   padding: 1rem;
+  box-sizing: border-box;
   overflow: auto;
   background-color: #f6faff;
   color: #002244;


### PR DESCRIPTION
## Summary
- size the editor textarea and preview pane with border-box so their padding stays inside the flex container
- prevent the editor content from sliding under the toolbar when long documents are pasted

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f113f96c832f9e24b3d5b5bcf24f