### PR TITLE
Add preview HTML export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ markdown-editor/
 | Toggle checkboxes in the preview | The matching task item in the Markdown source is toggled. |
 | Choose a template | Replace the current document with a starter outline from `template/`. |
 | Open / Save / Export PDF | Load Markdown from disk, download your work, or print the preview to PDF. |
+| Export preview HTML | Download the rendered preview as a standalone HTML file. |
 | Toggle the help window | Show or hide quick reference sheets for Markdown and Mermaid syntax. |
 
 ### Image placeholder example

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,7 @@
     "open": "📂 Open",
     "save": "💾 Save",
     "exportPdf": "📄 Export PDF",
+    "exportHtml": "🌐 Export HTML",
     "insertImage": "🖼 Insert Image",
     "template": "📋 Templates",
     "help": "❔ Help",
@@ -33,6 +34,7 @@
     "templateLoadErrorAlert": "Failed to load the template. Please make sure the template files are available.",
     "saveFilenamePrompt": "Enter a file name to save",
     "defaultFileName": "document.md",
+    "defaultHtmlFileName": "preview.html",
     "previewTitle": "Preview"
   },
   "editor": {

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -6,6 +6,7 @@
     "open": "📂 開く",
     "save": "💾 保存",
     "exportPdf": "📄 PDF出力",
+    "exportHtml": "🌐 HTML出力",
     "insertImage": "🖼 画像を挿入",
     "template": "📋 テンプレート",
     "help": "❔ ヘルプ",
@@ -33,6 +34,7 @@
     "templateLoadErrorAlert": "テンプレートの読み込みに失敗しました。テンプレートファイルの配置を確認してください。",
     "saveFilenamePrompt": "保存するファイル名を入力してください",
     "defaultFileName": "document.md",
+    "defaultHtmlFileName": "preview.html",
     "previewTitle": "プレビュー"
   },
   "editor": {

--- a/index.html
+++ b/index.html
@@ -14,6 +14,14 @@
       <button id="save-md" class="toolbar-button" type="button" data-i18n="toolbar.save">💾 Save</button>
       <button id="export-pdf" class="toolbar-button" type="button" data-i18n="toolbar.exportPdf">📄 Export PDF</button>
       <button
+        id="export-html"
+        class="toolbar-button"
+        type="button"
+        data-i18n="toolbar.exportHtml"
+      >
+        🌐 Export HTML
+      </button>
+      <button
         id="insert-image"
         class="toolbar-button"
         type="button"

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ function startApp() {
   const toc = document.getElementById('toc');
   const toolbar = document.getElementById('toolbar');
   const exportPdfBtn = document.getElementById('export-pdf');
+  const exportHtmlBtn = document.getElementById('export-html');
   const saveMdBtn = document.getElementById('save-md');
   const openMdBtn = document.getElementById('open-md');
   const helpBtn = document.getElementById('help-btn');
@@ -1200,25 +1201,61 @@ function startApp() {
     reader.readAsDataURL(file);
   });
 
-  exportPdfBtn.addEventListener('click', () => {
-    const win = window.open('', '', 'width=800,height=600');
-    if (!win) {
-      return;
-    }
-    const cssHref = document.querySelector('link[rel="stylesheet"]').href;
-    const previewTitle = i18n.t('dialogs.previewTitle');
-    const langAttr =
-      document.documentElement.getAttribute('lang') || i18n.getCurrentLang();
-    win.document.write(
-      `<!DOCTYPE html><html lang="${langAttr}"><head><meta charset="UTF-8"><title>${previewTitle}</title><link rel="stylesheet" href="${cssHref}"></head><body>${preview.innerHTML}</body></html>`
-    );
-    win.document.close();
-    win.onload = () => {
-      win.focus();
-      win.print();
-      win.close();
-    };
-  });
+  if (exportPdfBtn) {
+    exportPdfBtn.addEventListener('click', () => {
+      const win = window.open('', '', 'width=800,height=600');
+      if (!win) {
+        return;
+      }
+      const cssLink = document.querySelector('link[rel="stylesheet"]');
+      const cssHref = cssLink ? cssLink.href : '';
+      const previewTitle = i18n.t('dialogs.previewTitle');
+      const langAttr =
+        document.documentElement.getAttribute('lang') || i18n.getCurrentLang();
+      const linkTag = cssHref
+        ? `<link rel="stylesheet" href="${cssHref}">`
+        : '';
+      win.document.write(
+        `<!DOCTYPE html><html lang="${langAttr}"><head><meta charset="UTF-8"><title>${previewTitle}</title>${linkTag}</head><body>${preview.innerHTML}</body></html>`
+      );
+      win.document.close();
+      win.onload = () => {
+        win.focus();
+        win.print();
+        win.close();
+      };
+    });
+  }
+
+  if (exportHtmlBtn) {
+    exportHtmlBtn.addEventListener('click', () => {
+      const previewTitle = i18n.t('dialogs.previewTitle');
+      const langAttr =
+        document.documentElement.getAttribute('lang') || i18n.getCurrentLang();
+      const cssLink = document.querySelector('link[rel="stylesheet"]');
+      const cssHref = cssLink ? cssLink.href : '';
+      const linkTag = cssHref
+        ? `<link rel="stylesheet" href="${cssHref}">`
+        : '';
+      const html =
+        `<!DOCTYPE html><html lang="${langAttr}"><head><meta charset="UTF-8"><title>${previewTitle}</title>${linkTag}</head><body>${preview.innerHTML}</body></html>`;
+      const blob = new Blob([html], { type: 'text/html' });
+      const url = URL.createObjectURL(blob);
+      const defaultName = i18n.t('dialogs.defaultHtmlFileName');
+      const trimmedName =
+        typeof defaultName === 'string' && defaultName.trim()
+          ? defaultName.trim()
+          : 'preview.html';
+      const filename = trimmedName.endsWith('.html')
+        ? trimmedName
+        : `${trimmedName}.html`;
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+  }
 
   saveMdBtn.addEventListener('click', () => {
     const defaultName = i18n.t('dialogs.defaultFileName');

--- a/tests/actions.spec.js
+++ b/tests/actions.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require('@playwright/test');
+const fs = require('fs/promises');
+const os = require('os');
 const path = require('path');
 
 const fileUrl = 'file://' + path.resolve(__dirname, '../index.html');
@@ -159,6 +161,22 @@ test('exports PDF via button', async ({ page }) => {
   await expect(popup).toHaveTitle('Preview');
   await popup.close();
   expect(popup.isClosed()).toBeTruthy();
+});
+
+test('exports preview HTML via button', async ({ page }) => {
+  await page.goto(fileUrl);
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    page.click('#export-html'),
+  ]);
+  const suggestedFilename = await download.suggestedFilename();
+  expect(suggestedFilename).toMatch(/\.html$/);
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'md-html-'));
+  const targetPath = path.join(tempDir, suggestedFilename);
+  await download.saveAs(targetPath);
+  const html = await fs.readFile(targetPath, 'utf8');
+  expect(html).toContain('<!DOCTYPE html>');
+  expect(html).toContain('Welcome to Markdown Editor Blue');
 });
 
 test('inserts image into preview', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a toolbar control to download the rendered preview as an HTML document
- implement export logic with translation strings and PDF export fallback safeguards
- update documentation and end-to-end coverage for the new HTML export flow

## Testing
- npm test *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f7d08658832f83f306f33a226ae0