### PR TITLE
Fix copy action to clear selection after right-click copy

### DIFF
--- a/script.js
+++ b/script.js
@@ -1348,6 +1348,11 @@ function startApp() {
       return;
     }
 
+    const collapseSelection = () => {
+      editor.selectionStart = selectionEnd;
+      editor.selectionEnd = selectionEnd;
+    };
+
     const attemptExecCommandCopy = () => {
       const activeElement = document.activeElement;
       try {
@@ -1360,6 +1365,7 @@ function startApp() {
       } catch (error) {
         // Ignore copy errors to avoid interrupting the user experience.
       } finally {
+        collapseSelection();
         if (
           activeElement &&
           activeElement !== editor &&
@@ -1382,6 +1388,7 @@ function startApp() {
             clipboardHasText = true;
             updateClipboardButtonStates();
           }
+          collapseSelection();
         })
         .catch(attemptExecCommandCopy);
     } else {


### PR DESCRIPTION
## Summary
- collapse the editor selection after copying text via the context menu so highlighting disappears as expected
- ensure the selection is cleared for both asynchronous clipboard and execCommand copy paths

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f86fe80334832fbc5c424bb8d0ce21